### PR TITLE
#48: Upgrading log4j version. Refactoring MWLogger instead of removin…

### DIFF
--- a/MekWarsCommon/src/mekwars/common/CampaignData.java
+++ b/MekWarsCommon/src/mekwars/common/CampaignData.java
@@ -29,27 +29,22 @@ import java.util.Properties;
 import java.util.TreeMap;
 import java.util.Vector;
 
-import mekwars.common.House;
 import mekwars.common.util.BinReader;
 import mekwars.common.util.BinWriter;
 import mekwars.common.util.MWLogger;
 import megamek.common.AmmoType;
-
 
 /**
  * TODO: It seems, that all operations done here are needed independly of the
  * semantic of the underlying structure. Planets are handled equal to factions
  * and each function is doubled. If this is true, it should be managed in an
  * generic way to reduce code bloat and code replication.
- * 
  * Campaign is the base of the data holding classes for client and server. Here
  * all campaign relevant information as Houses, Planets and Player data is
  * stored.
- * 
  * In this base class some methods are provided to retrieve these informations
  * to use in common data classes like House or Planet when reffering to
  * ressources.
- * 
  * Notice: Please read the doc to binOut before adding new data types.
  * 
  * @author Imi (immanuel.scholz@gmx.de)
@@ -115,8 +110,7 @@ public class CampaignData implements TerrainProvider {
             Integer planetID = planetid.get(name.toLowerCase());
             return getPlanet(planetID);
         } catch (Exception ex) {
-            MWLogger.errLog("Looking for planet: " + name);
-            // MWLogger.errLog(ex);
+            MWLogger.errLog("Could not find planet: " + name);
             return null;
         }
     }

--- a/MekWarsCommon/src/mekwars/common/util/MWLogger.java
+++ b/MekWarsCommon/src/mekwars/common/util/MWLogger.java
@@ -13,156 +13,143 @@
  * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
  */
-
 package mekwars.common.util;
 
-import java.io.File;
-
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.MarkerManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
 
+public interface MWLogger {
+    Logger LOGGER = LogManager.getLogger(MWLogger.class);
 
-public final class MWLogger {// final - no extension of the server logger
+    Marker RESULTS_MARKER = MarkerManager.getMarker("resultsLog");
+    Marker GAME_MARKER = MarkerManager.getMarker("gameLog");
+    Marker TEST_MARKER = MarkerManager.getMarker("testLog");
+    Marker TICK_MARKER = MarkerManager.getMarker("tickLog");
+    Marker PM_MARKER = MarkerManager.getMarker("pmLog");
 
-    private File logDir;
-    private static MWLogger logger = null;
-    
-    private MWLogger() {
-        LogManager.getLogger().info("MWLogger Started");
+    static void errLog(String message) {
+        LOGGER.error(message);
     }
     
-    public static MWLogger getInstance() {
-        if (logger == null) {
-            logger = new MWLogger();
-        }
-        return logger;
-    }
-    
-    public static void errLog(String message) {
-       LogManager.getLogger().error(message);
-    }
-    
-    public static void mainLog(String message) {
-        LogManager.getLogger().info(message);
-    }
-    
-    public static void modLog(String message) {
-        LogManager.getLogger().log(Level.INFO, message);
-    }
-    
-    public static void debugLog(String message) {
-        LogManager.getLogger().debug(message);
-    }
-    
-    public static void ipLog(String message) {
-        LogManager.getLogger().info(message);
-    }
-    
-    public static void cmdLog(String message) {
-        LogManager.getLogger().error(message);
-    }
-    
-    public static void errLog(Exception e) {
-        LogManager.getLogger().error(e);
-    }
-    
-    public static void mainLog(Exception e) {
-        LogManager.getLogger().info(e);
-    }
-    
-    public static void modLog(Exception e) {
-        LogManager.getLogger().info(e);
-    }
-    
-    public static void debugLog(Exception e) {
-        LogManager.getLogger().info(e);
-    }
-    
-    public static void ipLog(Exception e) {
-        LogManager.getLogger().info(e);
-    }
-    
-    public static void cmdLog(Exception e) {
-        LogManager.getLogger().info(e);
-    }
-    
-    public static void infoLog(String message) {
-        LogManager.getLogger().info(message);
-    }
-    
-    public static void infoLog(Exception e) {
-        LogManager.getLogger().info(e);
+    static void mainLog(String message) {
+        LOGGER.info(message);
     }
 
-    public static void bmLog(String message) {
-        LogManager.getLogger().info(message);
+    static void modLog(String message) {
+        LOGGER.info(message);
     }
     
-    public static void bmLog(Exception e) {
-        LogManager.getLogger().info(e);
-    }
-    public static void resultsLog(String message) {
-        final Marker results = MarkerManager.getMarker("resutlsLog");
-        LogManager.getLogger().info(results, message);
+    static void debugLog(String message) {
+        LOGGER.debug(message);
     }
     
-    public static void resultsLog(Exception e) {
-        LogManager.getLogger().info(e);
+    static void ipLog(String message) {
+        LOGGER.info(message);
+    }
+    
+    static void cmdLog(String message) {
+        LOGGER.error(message);
     }
 
-    public static void gameLog(String message) {
-        final Marker game = MarkerManager.getMarker("gameLog");
-        LogManager.getLogger().info(game, message);
+    static void infoLog(String message) {
+        LOGGER.info(message);
     }
-    
-    public static void gameLog(Exception e) {
-        LogManager.getLogger().info(e);
+
+    static void bmLog(String message) {
+        LOGGER.info(message);
     }
-    
-    public static void testLog(String message) {
-        final Marker test = MarkerManager.getMarker("testLog");
-        LogManager.getLogger().info(test, message);
+
+    static void resultsLog(String message) {
+        LOGGER.info(RESULTS_MARKER, message);
     }
-    
-    public static void testLog(Exception e) {
-        LogManager.getLogger().info(e);
+
+    static void gameLog(String message) {
+        LOGGER.info(GAME_MARKER, message);
     }
-    
-    public static void tickLog(String message) {
-        final Marker tick = MarkerManager.getMarker("tickLog");
-        LogManager.getLogger().info(tick, message);
+
+    static void testLog(String message) {
+        LOGGER.info(TEST_MARKER, message);
     }
-    
-    public static void tickLog(Exception e) {
-        LogManager.getLogger().info(e);
+
+    static void tickLog(String message) {
+        LOGGER.info(TICK_MARKER, message);
     }
-    
-    public static void warnLog(String message) {
-        LogManager.getLogger().warn(message);
+
+    static void warnLog(String message) {
+        LOGGER.warn(message);
     }
-    
-    public static void warnLog(Exception e) {
-        LogManager.getLogger().warn(e);
+
+    static void pmLog(String message) {
+        LOGGER.info(PM_MARKER, message);
     }
-    
-    public static void pmLog(String message) {
-        final Marker pm = MarkerManager.getMarker("pmLog");
-        LogManager.getLogger().info(pm, message);
-    }
-    
-    public static void pmLog(Exception e) {
-        LogManager.getLogger().info(e);
-    }
-    
-    public static void factionLog(String factionName, String message) {
+
+    // Can't have a method like this here without a rework, note it is unused anyway
+    static void factionLog(String factionName, String message) {
         final Marker faction = MarkerManager.getMarker(factionName);
-        LogManager.getLogger().info(faction, message);
+        LOGGER.info(faction, message);
+    }
+
+    static void errLog(Exception e) {
+        LOGGER.error("Exception: ", e);
     }
     
-    public static void factionLog(String factionName, Exception e) {
+    static void mainLog(Exception e) {
+        LOGGER.info("Exception: ", e);
+    }
+    
+    static void modLog(Exception e) {
+        LOGGER.info("Exception: ", e);
+    }
+    
+    static void debugLog(Exception e) {
+        LOGGER.info("Exception: ", e);
+    }
+    
+    static void ipLog(Exception e) {
+        LOGGER.info("Exception: ", e);
+    }
+    
+    static void cmdLog(Exception e) {
+        LOGGER.info("Exception: ", e);
+    }
+    
+    static void infoLog(Exception e) {
+        LOGGER.info("Exception: ", e);
+    }
+
+    static void bmLog(Exception e) {
+        LOGGER.info("Exception: ", e);
+    }
+
+    static void resultsLog(Exception e) {
+        LOGGER.info(RESULTS_MARKER, "Exception: ", e);
+    }
+
+    static void gameLog(Exception e) {
+        LOGGER.info(GAME_MARKER, "Exception: ", e);
+    }
+
+    static void testLog(Exception e) {
+        LOGGER.info(e);
+    }
+    
+    static void tickLog(Exception e) {
+        LOGGER.info(e);
+    }
+    
+    static void warnLog(Exception e) {
+        LOGGER.warn(e);
+    }
+    
+    static void pmLog(Exception e) {
+        LOGGER.info(e);
+    }
+
+    // Can't have a method like this here without a rework, note it is unused anyway
+    static void factionLog(String factionName, Exception e) {
         final Marker factiondebug = MarkerManager.getMarker(factionName);
-        LogManager.getLogger().debug(factiondebug, e.getMessage());
+        LOGGER.debug(factiondebug, e.getMessage());
     }
 }

--- a/buildSrc/src/main/groovy/java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/java-common-conventions.gradle
@@ -6,8 +6,8 @@ dependencies {
 	implementation "org.megamek:megamek:${mmVersion}"
 
 	implementation 'org.quartz-scheduler:quartz:2.2.3'
-	implementation 'org.apache.logging.log4j:log4j-core:2.24.3'
-	implementation 'org.apache.logging.log4j:log4j-api:2.24.3'
+	implementation 'org.apache.logging.log4j:log4j-core:2.25.2'
+	implementation 'org.apache.logging.log4j:log4j-api:2.25.2'
 	implementation 'com.thoughtworks.xstream:xstream:1.4.14'
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'


### PR DESCRIPTION
…g it (for now), changing to static utility interface to allow for code hotswap. Remove repeated lookups for logger instance (removes lookup overhead, ensures same logger instance every time which matters for concurrency). Keeping dead code for now, refactor to remove this class will likely streamline it. Changing to static Marker instances to avoid marker creation on every method call. Add messages to exception logs so that the exception's stack trace is always shown. Note that there are no public static final keywords since in an interface all members are implicitly public static final.

Tested with locally running server, all logs cehcked in:
[INFO ] 2025-11-03 15:39:08.131 [main] MWLogger - ----- MekWars Server V 9.0.0 is starting up... -----
[INFO ] 2025-11-03 15:39:08.573 [main] MWLogger - Loading configuration...
[INFO ] 2025-11-03 15:39:08.573 [main] MWLogger - Loading Ban Players
[INFO ] 2025-11-03 15:39:08.573 [main] MWLogger - Loading ISPs
[INFO ] 2025-11-03 15:39:08.573 [main] MWLogger - Configuration loaded.
[INFO ] 2025-11-03 15:39:08.573 [main] MWLogger - Loading mail file...
[INFO ] 2025-11-03 15:39:08.573 [main] MWLogger - Mail file loaded.
[INFO ] 2025-11-03 15:39:08.573 [main] MWLogger - Creating new campaign environment...
[INFO ] 2025-11-03 15:39:08.932 [main] CampaignMain - Loading MegaMek Game Options
...
[ERROR] 2025-11-03 15:39:09.551 [main] MWLogger - Server errors log touched.
[INFO ] 2025-11-03 15:39:09.551 [main] MWLogger - Moderators log touched.
[INFO ] 2025-11-03 15:39:09.551 [main] MWLogger - Tick report log touched.
[INFO ] 2025-11-03 15:39:09.551 [main] MWLogger - Entering main loop cycle. Starting the server...
[INFO ] 2025-11-03 15:39:09.551 [main] MWLogger - infoLog war birdies 
[INFO ] 2025-11-03 15:39:09.551 [main] MWLogger - infoLog war birdies
[INFO ] 2025-11-03 15:39:09.551 [main] MWLogger - infoLog war birdies
[INFO ] 2025-11-03 15:39:09.551 [main] MWLogger - infoLog war birdies
[INFO ] 2025-11-03 15:39:09.551 [main] MWLogger - infoLog war birdies
[ERROR] 2025-11-03 15:39:09.551 [main] MWLogger - infoLog war birdies
[INFO ] 2025-11-03 15:39:09.551 [main] MWLogger - infoLog war birdies
[INFO ] 2025-11-03 15:39:09.551 [main] MWLogger - CommandProcessorRemote: initting the comm command processor
Note the lines infoLog war birdies (some silly words). These are produced by the following (now removed) test lines in MWServ's main method:

```
public static void main(String[] argv) {
    MWServ.getInstance();
    // start the TrackerThread if using tracker
    MWServ.getInstance().startTracker();
    
    //start server
    MWLogger.mainLog("Entering main loop cycle. Starting the server...");
    MWLogger.resultsLog("infoLog war birdies");
    MWLogger.gameLog("infoLog war birdies");
    MWLogger.testLog("infoLog war birdies");
    MWLogger.tickLog("infoLog war birdies");
    MWLogger.pmLog("infoLog war birdies");
    MWLogger.errLog("infoLog war birdies");
    MWLogger.modLog("infoLog war birdies");

    MWServ.getInstance().startServer();
}
