### PR TITLE
#104: Adding the data/images directory to the install task.

### DIFF
--- a/MekWarsClient/build.gradle
+++ b/MekWarsClient/build.gradle
@@ -87,17 +87,25 @@ tasks.named('installDist') {
     }
 }
 
-
 distributions {
     main {
         contents {
             from stageFiles
             from jar
             from "${mmDir}/megamek/build/libs/MegaMek.jar"
+
             from (project.sourceSets.main.runtimeClasspath.files
                     .findAll { it.name.endsWith(".jar") }) {
                 into "${lib}"
             }
+
+            // execute build with -PexcludeData to skip data copy
+            if (!project.hasProperty('excludeData')) {
+                from("${mmDir}/megamek/data/images") {
+                    into "data/images"
+                }
+            }
+
             duplicatesStrategy = 'exclude'
         }
     }


### PR DESCRIPTION
Missing anything else? The install task should provide a completely working client but I'm guessing there are more manual copies that may be required with this iteration