### PR TITLE
#118 Add EntityStore

### DIFF
--- a/MekWarsCommon/src/mekwars/common/AdvancedTerrain.java
+++ b/MekWarsCommon/src/mekwars/common/AdvancedTerrain.java
@@ -19,7 +19,8 @@ package mekwars.common;
 
 import java.io.IOException;
 import java.util.StringTokenizer;
-
+import mekwars.common.entities.Entity;
+import mekwars.common.persistence.EntityStore;
 import mekwars.common.util.BinReader;
 import mekwars.common.util.BinWriter;
 import mekwars.common.util.TokenReader;
@@ -38,9 +39,9 @@ import megamek.common.planetaryconditions.WindDirection;
  * @@author Torren (Jason Tighe) allows So's to set up each individual terrain on a planet.
  */
 
-final public class AdvancedTerrain {
+public class AdvancedTerrain implements Entity {
     private String displayName = "none";
-    private int id = 0;
+    private int id = EntityStore.UNSET_ID;
     private String name = "none";
     
     //NOTE: These fields are unused and kept to keep the xml file consistent
@@ -112,6 +113,8 @@ final public class AdvancedTerrain {
         }
 
         result += "$";
+        result += name;
+        result += "$";
         result += lowTemp;
         result += "$";
         result += highTemp;
@@ -181,7 +184,7 @@ final public class AdvancedTerrain {
 
     public void binIn(BinReader in) throws IOException {
         displayName = in.readLine("displayName");
-        name = displayName;
+        name = in.readLine("name");
         lowTemp = in.readInt("lowTemp");
         highTemp = in.readInt("highTemp");
         gravity = in.readDouble("gravity");
@@ -217,8 +220,8 @@ final public class AdvancedTerrain {
     }
 
     public void binOut(BinWriter out) throws IOException {
-
         out.println(displayName, "displayName");
+        out.println(name, "name");
         out.println(lowTemp, "lowTemp");
         out.println(highTemp, "highTemp");
         out.println(gravity, "gravity");
@@ -551,6 +554,7 @@ final public class AdvancedTerrain {
         AdvancedTerrain clone = new AdvancedTerrain();
         clone.setAtmosphere(atmosphere);
         clone.setDisplayName(displayName);
+        clone.setName(name);
         clone.setDownPourChance(downPourChance);
         clone.setDuskChance(duskChance);
         clone.setEMI(emi);

--- a/MekWarsCommon/src/mekwars/common/CampaignData.java
+++ b/MekWarsCommon/src/mekwars/common/CampaignData.java
@@ -16,9 +16,6 @@
 
 package mekwars.common;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -28,10 +25,12 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.TreeMap;
 import java.util.Vector;
-
+import megamek.common.AmmoType;
 import mekwars.common.util.BinReader;
 import mekwars.common.util.BinWriter;
-import megamek.common.AmmoType;
+import mekwars.common.persistence.NamedEntityStore;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * TODO: It seems, that all operations done here are needed independly of the
@@ -53,33 +52,10 @@ public class CampaignData implements TerrainProvider {
 
     public static CampaignData cd;
 
-    /**
-     * All different Houses are stored here. key=Integer (id), value=House
-     */
-    private TreeMap<Integer, House> factions = new TreeMap<>();
-
-    /**
-     * All different House ids are stored here key=String (name), value=int id
-     */
-    private TreeMap<String, Integer> factionid = new TreeMap<>();
-
-    /**
-     * This is a list with all planet information stored. key=Integer (id),
-     * value=Planet (or subclasses for server and client)
-     */
-    private TreeMap<Integer, Planet> planets = new TreeMap<>();
-
-    /**
-     * This is a list with planet id stored. key=String (name), value=int id
-     */
-    private TreeMap<String, Integer> planetid = new TreeMap<>();
-
-    /**
-     * List of all terrains that can occur on surfaces of planets.
-     */
-    private ArrayList<Terrain> terrains = new ArrayList<>();
-    private ArrayList<AdvancedTerrain> advTerrains = new ArrayList<>();
-    
+    private NamedEntityStore<House> factions = new NamedEntityStore<>();
+    private NamedEntityStore<Planet> planets = new NamedEntityStore<>();
+    private NamedEntityStore<Terrain> terrains = new NamedEntityStore<>();
+    private NamedEntityStore<AdvancedTerrain> advancedTerrains = new NamedEntityStore<>();
 
     private Hashtable<String, String> ServerBannedAmmo = new Hashtable<>();
     private Vector<Integer> bannedTargetingSystems = new Vector<>();
@@ -104,14 +80,7 @@ public class CampaignData implements TerrainProvider {
      * for a planet instead (if you have the choice).
      */
     public Planet getPlanetByName(String name) {
-
-        try {
-            Integer planetID = planetid.get(name.toLowerCase());
-            return getPlanet(planetID);
-        } catch (Exception ex) {
-            LOGGER.error("Could not find planet: {}", name);
-            return null;
-        }
+        return planets.getByName(name);
     }
 
     /**
@@ -122,36 +91,6 @@ public class CampaignData implements TerrainProvider {
         for (UnitFactory e : p.getUnitFactories()) {
             if (e.getName().equalsIgnoreCase(name)) {
                 return e;
-            }
-        }
-        return null;
-    }
-
-    /**
-     * @author Torren (Jason Tighe)
-     * @param planet
-     * @param Factory
-     * 
-     *            Updates the Client side factories Useful for the factory
-     *            Refresh with RP
-     */
-    public void updateFactoryTick(String planet, String factory, int tick) {
-        Planet p = getPlanetByName(planet);
-        UnitFactory unitFactory = getFactoryByName(p, factory);
-        unitFactory.setTicksUntilRefresh(tick);
-    }
-
-    /**
-     * Check if the planet name was only partial and complete it..
-     */
-    public Planet getPlanetByPartialName(String name) {
-        for (Planet p : getAllPlanets()) {
-            if (p.getName().equals(name)) {
-                return p;
-            }
-
-            if (p.getName().indexOf(name) != -1) {
-                return p;
             }
         }
         return null;
@@ -173,12 +112,7 @@ public class CampaignData implements TerrainProvider {
      * @see You should use XStream to initialize CampaignData
      */
     public void addPlanet(Planet planet) {
-        LOGGER.info("Adding Planet: '{}'", planet.getName());
-        if (planet.getId() == -1) {
-            planet.setId(getUnusedPlanetID());
-        }
-        planets.put(planet.getId(), planet);
-        planetid.put(planet.getName().toLowerCase(), planet.getId());
+        planets.put(planet);
     }
 
     /**
@@ -188,7 +122,6 @@ public class CampaignData implements TerrainProvider {
      *            The id of the blown up planet.
      */
     public void removePlanet(int id) {
-        planetid.remove(getPlanet(id).getName().toLowerCase());
         planets.remove(id);
     }
 
@@ -197,22 +130,6 @@ public class CampaignData implements TerrainProvider {
      */
     public void clearPlanets() {
         planets.clear();
-    }
-
-    /**
-     * Retrieve an unused id for planets.
-     * 
-     * @TODO There should be no need for such function, since ID's should
-     *       extracted from ressource files. This function will vanish if ids
-     *       are part of the ressource.
-     * @return An Planet id not used yet.
-     */
-    public int getUnusedPlanetID() {
-        int id = 0;
-        while (planets.keySet().contains(id)) {
-            id++;
-        }
-        return id;
     }
 
     /**
@@ -242,9 +159,7 @@ public class CampaignData implements TerrainProvider {
      * @TODO You should use XStream to initialize CampaignData
      */
     public void addHouse(House faction) {
-        LOGGER.info("Adding House: '{}'", faction.getName());
-        factions.put(faction.getId(), faction);
-        factionid.put(faction.getName().toLowerCase(), faction.getId());
+        factions.put(faction);
     }
 
     /**
@@ -255,8 +170,12 @@ public class CampaignData implements TerrainProvider {
      *            id
      */
     public void removeHouse(int id) {
-        String factionName = getHouse(id).getName().toLowerCase();
-        factionid.remove(factionName);
+        House faction = factions.get(id);
+
+        if (faction == null) {
+            return;
+        }
+        String factionName = faction.getName().toLowerCase();
         factions.remove(id);
 
         File factionFile = new File("./campaign/factions/" + factionName + ".dat");
@@ -279,12 +198,7 @@ public class CampaignData implements TerrainProvider {
      *       transmitting the factions name instead of its id.
      */
     public House getHouseByName(String name) {
-        try {
-            House h = getHouse(factionid.get(name.toLowerCase()));
-            return h;
-        } catch (Exception ex) {
-            return null;
-        }
+        return factions.getByName(name);
     }
 
     /**
@@ -292,43 +206,6 @@ public class CampaignData implements TerrainProvider {
      */
     public void clearHouses() {
         factions.clear();
-    }
-
-    /**
-     * Retrieve an unused id for terrains. Only used upon start up of a new
-     * server using XML files.
-     * 
-     * @return An terrain id not used yet.
-     */
-    public int getUnusedTerrainID() {
-        int id = -1;
-        int hid = -1;
-        for (Terrain e : terrains) {
-            hid = e.getId();
-            if (hid > id) {
-                id = hid;
-            }
-        }
-        id++;
-        return id;
-    }
-    /**
-     * Retrieve an unused id for advterrains. Only used upon start up of a new
-     * server using XML files.
-     * 
-     * @return An terrain id not used yet.
-     */
-    public int getUnusedAdvTerrainID() {
-        int id = -1;
-        int hid = -1;
-        for (AdvancedTerrain e : advTerrains) {
-            hid = e.getId();
-            if (hid > id) {
-                id = hid;
-            }
-        }
-        id++;
-        return id;
     }
 
     /**
@@ -384,11 +261,11 @@ public class CampaignData implements TerrainProvider {
      */
     public void binTerrainsOut(BinWriter out) throws IOException {
         out.println(terrains.size(), "terrains.size");
-        for (Terrain pe : terrains) {
+        for (Terrain pe : terrains.values()) {
             pe.binOut(out);
         }
-        out.println(advTerrains.size(), "advTerrains.size");
-        for (AdvancedTerrain pe : advTerrains) {
+        out.println(advancedTerrains.size(), "advTerrains.size");
+        for (AdvancedTerrain pe : advancedTerrains.values()) {
             pe.binOut(out);
         }
         
@@ -423,7 +300,6 @@ public class CampaignData implements TerrainProvider {
      */
     public CampaignData() {
         cd = this;
-        PlanetEnvironments.data = this;
     }
 
     /**
@@ -431,7 +307,6 @@ public class CampaignData implements TerrainProvider {
      */
     public CampaignData(BinReader in) throws IOException {
         cd = this;
-        PlanetEnvironments.data = this;
         int size = in.readInt("terrains.size");
         for (int i = 0; i < size; ++i) {
             Terrain pe = new Terrain();
@@ -452,101 +327,33 @@ public class CampaignData implements TerrainProvider {
 
         size = in.readInt("planets.size");
         for (int i = 0; i < size; ++i) {
-            addPlanet(new Planet(in, factions, this));
+            addPlanet(new Planet(in, this));
         }
     }
-
-    /**
-     * Updates sent Planets due a differential update.
-     * 
-     * @param changesSinceLastRefresh
-     *            A map to hold the change in planet ids that got updated this
-     *            refresh. Structure is as follows: key=planetID(Integer),
-     *            value=Influences(differential)
-     */
-    public void decodeMutablePlanets(BinReader in, Map<Integer, Influences> changesSinceLastRefresh) throws IOException {
-        int count = in.readInt("mutableplanetsize");
-        System.out.println("retrieving " + count + " planets due differential update.");
-        changesSinceLastRefresh.clear();
-        for (int i = 0; i < count; ++i) {
-            int id = in.readInt("planetid");
-            Influences infOld = new Influences(getPlanet(id).getInfluence());
-            getPlanet(id).decodeMutableFields(in, this);
-            Influences infNew = getPlanet(id).getInfluence();
-            changesSinceLastRefresh.put(id, infNew.difference(infOld));
-        }
-    }
-
-    /**
-     * Writes some planets due a differential update
-     * 
-     * @param ids
-     *            A collection of java.lang.Integer with the ids to send.
-     */
-    public void encodeMutablePlanets(BinWriter out, Collection<Integer> ids) throws IOException {
-        out.println(ids.size(), "mutableplanetsize");
-        for (Integer id : ids) {
-            out.println(id, "planetid");
-            getPlanet(id).encodeMutableFields(out, this);
-        }
-    }
-
-    /**
-     * Saves itself to disk. This uses the dynamic type of each object to make a
-     * copy as close to the real data as possible. Use loadData() to read it
-     * back to memory.
-     * 
-     * public void saveData(File directory) throws IOException { if (directory
-     * == null) throw new
-     * IllegalArgumentException("Please specify a directory."); if
-     * (directory.exists() && !directory.isDirectory()) throw new
-     * IllegalArgumentException(directory.getName()+" is not a directory."); if
-     * (!directory.exists()) directory.mkdir(); MMNetXStream xml = new
-     * MMNetXStream(new DomDriver()); xml.toXML(this,new
-     * FileWriter(directory.getPath()+"/data.xml"));
-     * 
-     * DatWriter datWriter = new
-     * DatWriter(directory.getPath()+"/CampaignData.dat");
-     * datWriter.write(this,"CampaignData"); datWriter.close(); }
-     */
 
     /**
      * @see common.TerrainProvider#getTerrain(int)
      */
     public Terrain getTerrain(int id) {
-        for (Terrain env : terrains) {
-            if (env.getId() == id) {
-                return env;
-            }
-        }
-        return null;
-
+        return terrains.get(id);
     }
 
     /**
      * @see common.TerrainProvider#getAllTerrains()
      */
     public Collection<Terrain> getAllTerrains() {
-        return terrains;
+        return terrains.values();
     }
 
     /**
      * @see common.TerrainProvider#addTerrain(common.PlanetEnvironment)
      */
     public void addTerrain(Terrain terrain) {
-        LOGGER.info("Adding Terrain: '{}'", terrain.getName());
-        terrain.setId(getUnusedTerrainID());
-        terrains.add(terrain);
-        terrains.trimToSize();
+        terrains.put(terrain);
     }
 
-    public Terrain getTerrainByName(String TerrainName) {
-        for (Terrain env : terrains) {
-            if (env.getName().equalsIgnoreCase(TerrainName)) {
-                return env;
-            }
-        }
-        return null;
+    public Terrain getTerrainByName(String name) {
+        return terrains.getByName(name);
     }
 
     /*adding the advanced terrain to the campaign data*/
@@ -554,79 +361,27 @@ public class CampaignData implements TerrainProvider {
      * @see common.TerrainProvider#getAdvancedTerrain(int)
      */
     public AdvancedTerrain getAdvancedTerrain(int id) {
-        for (AdvancedTerrain env : advTerrains) {
-            if (env.getId() == id) {
-                return env;
-            }
-        }
-        return new AdvancedTerrain();
+        return advancedTerrains.get(id);
     }
 
     /**
      * @see common.TerrainProvider#getAllTerrains()
      */
     public Collection<AdvancedTerrain> getAllAdvancedTerrains() {
-        return advTerrains;
+        return advancedTerrains.values();
     }
 
     /**
      * @see common.TerrainProvider#addTerrain(common.PlanetEnvironment)
      */
     public void addAdvancedTerrain(AdvancedTerrain newAdvTerrain) {
-        LOGGER.info("Adding AdvancedTerrain: '{}'", newAdvTerrain.getName());
-        newAdvTerrain.setId(getUnusedAdvTerrainID());
-        advTerrains.add(newAdvTerrain);
-        advTerrains.trimToSize();
+        advancedTerrains.put(newAdvTerrain);
     }
 
-    public AdvancedTerrain getAdvancedTerrainByName(String AdvTerrainName) {
-        for (AdvancedTerrain env : advTerrains) {
-            if (env.getName().equalsIgnoreCase(AdvTerrainName)) {
-                return env;
-            }
-        }
-        return new AdvancedTerrain();
+    public AdvancedTerrain getAdvancedTerrainByName(String name) {
+        return advancedTerrains.getByName(name);
     }
 
-    
-    /**
-     * @see common.persistence.MMNetSerializable#binOut(common.persistence.TreeWriter)
-     * 
-          public void binOut(TreeWriter out) { out.write(terrains, "terrains");
-     *      out.startDataBlock("factions"); out.write(factions.size(),
-     *      "factionsCount"); for (House h : factions.values()) {
-     *      out.write(h.getClass().getName(), "factionType"); out.write(h,
-     *      "faction"); } out.endDataBlock("factions");
-     *      out.startDataBlock("planets"); out.write(factions.size(),
-     *      "planetsCount"); for (Planet p : planets.values()) {
-     *      out.write(p.getClass().getName(), "planetType"); out.write(p,
-     *      "planet"); } out.endDataBlock("planets"); }
-     */
-
-    /**
-     * @see common.persistence.MMNetSerializable#binIn(common.persistence.TreeReader)
-     * 
-          public void binIn(TreeReader in, CampaignData dataProvider) throws
-     *      IOException { terrains.clear(); in.startDataBlock("factions");
-     *      factions.clear(); int size = in.readInt("factionsCount"); for (int i
-     *      = 0; i < size; ++i) { String type = in.readString("factionType");
-     *      try { House h = (House) Class.forName(type).newInstance();
-     *      in.readObject(h, this, "faction"); factions.put(new
-     *      Integer(h.getId()), h); } catch (InstantiationException e) {
-     *      LOGGER.error("Exception: ", e); } catch (IllegalAccessException e) {
-     *      LOGGER.error("Exception: ", e); } catch (ClassNotFoundException e) {
-     *      LOGGER.error("Exception: ", e); } } in.endDataBlock("factions");
-     * 
-     *      in.startDataBlock("planets"); planets.clear(); size =
-     *      in.readInt("planetsCount"); for (int i = 0; i < size; ++i) { String
-     *      type = in.readString("planetsType"); try { Planet p = (Planet)
-     *      Class.forName(type).newInstance(); in.readObject(p, this, "planet");
-     *      planets.put(new Integer(p.getId()), p); } catch
-     *      (InstantiationException e) { LOGGER.error("Exception: ", e); } catch
-     *      (IllegalAccessException e) { LOGGER.error("Exception: ", e); } catch
-     *      (ClassNotFoundException e) { LOGGER.error("Exception: ", e); } }
-     *      in.endDataBlock("planets"); }
-     */
     /**
      * @author Torren (Jason Tighe)
      * 
@@ -811,6 +566,7 @@ public class CampaignData implements TerrainProvider {
                 commandTemp.put(commandName, accessLevel);
             }
         } catch (Exception ex) {
+            LOGGER.error("Unable to import acccess levels", ex);
         } // in is empty move on.
         setCommandTable(commandTemp);
     }
@@ -828,7 +584,6 @@ public class CampaignData implements TerrainProvider {
 
         if (getCommandTable().get(command.toUpperCase()) != null) {
             level = getCommandTable().get(command.toUpperCase()).intValue();
-            // LOGGER.error("Command: "+command+" level: "+level);
         }
 
         return level;

--- a/MekWarsCommon/src/mekwars/common/House.java
+++ b/MekWarsCommon/src/mekwars/common/House.java
@@ -20,6 +20,8 @@
  */
 package mekwars.common;
 
+import mekwars.common.entities.Entity;
+import mekwars.common.persistence.EntityStore;
 import mekwars.common.util.BinReader;
 import mekwars.common.util.BinWriter;
 import mekwars.common.util.HTMLConverter;
@@ -36,9 +38,7 @@ import megamek.common.TechConstants;
  * @author Helge Richter
  * 
  */
-public class House {
-    private static int HouseId = 0;
-
+public class House implements Entity {
     public static final int RED_VALUE = 0;
     public static final int GREEN_VALUE = 1;
     public static final int BLUE_VALUE = 2;
@@ -47,8 +47,7 @@ public class House {
     private String logo = "";
     private String factionFluFile = "Common";
 
-    private Integer id;
-    private int dbId = 0;
+    private int id;
     private Vector<Integer> baseGunner = new Vector<Integer>(Unit.MAXBUILD, 1);
     private Vector<Integer> basePilot = new Vector<Integer>(Unit.MAXBUILD, 1);
     private Vector<String> basePilotSkills = new Vector<String>(Unit.MAXBUILD, 1);
@@ -284,22 +283,11 @@ public class House {
      * @return Returns the id.
      */
     public int getId() {
-        if (id == null)
-            return -1;
-        return id.intValue();
+        return id;
     }
-
-    public int getDBId() {
-        return dbId;
-    }
-
-    public void setDBId(int id) {
-        dbId = id;
-    }
-
 
     public House() {
-        this.id = HouseId++;
+        setId(EntityStore.UNSET_ID);
         for (int pos = 0; pos < Unit.MAXBUILD; pos++) {
             baseGunner.add(4);
             basePilot.add(5);
@@ -311,7 +299,7 @@ public class House {
      * Write itself to an binary stream.
      */
     public void binOut(BinWriter out) throws IOException {
-        out.println(id.intValue(), "id");
+        out.println(id, "id");
         out.println(name, "name");
         out.println(logo, "logo");
         out.println(getBaseGunner(), "baseGunner");

--- a/MekWarsCommon/src/mekwars/common/Planet.java
+++ b/MekWarsCommon/src/mekwars/common/Planet.java
@@ -23,13 +23,13 @@ package mekwars.common;
 import java.awt.Dimension;
 import java.io.File;
 import java.io.IOException;
-import java.util.Map;
-import java.util.TreeMap;
 import java.util.ArrayList;
-
+import java.util.TreeMap;
+import mekwars.common.persistence.EntityStore;
 import mekwars.common.util.BinReader;
 import mekwars.common.util.BinWriter;
 import mekwars.common.util.Position;
+import mekwars.common.entities.Entity;
 import megamek.common.planetaryconditions.PlanetaryConditions;
 
 /**
@@ -37,15 +37,13 @@ import megamek.common.planetaryconditions.PlanetaryConditions;
  * 
  */
 
-public class Planet implements Comparable<Object>, MutableSerializable {
-    private static int PlanetId = 0;
-
+public class Planet implements Comparable<Object>, MutableSerializable, Entity {
     // VARIABLES
     /**
      * Unique id of this planet. Mutable field (although it will not change, it
      * has to be transfered)
      */
-    private int id;
+    private int id = EntityStore.UNSET_ID;
 
     /**
      * name of the planet. Should be unique among planets too.
@@ -144,7 +142,6 @@ public class Planet implements Comparable<Object>, MutableSerializable {
         if(influence == null) {
             throw new IllegalArgumentException();
         }
-        setId(PlanetId++);
         setName(name);
         setPosition(position);
         setInfluence(influence);
@@ -160,7 +157,7 @@ public class Planet implements Comparable<Object>, MutableSerializable {
     /**
      * Read the stream back to a Planet object.
      */
-    public Planet(BinReader in, Map<Integer, House> factions, CampaignData data) throws IOException {
+    public Planet(BinReader in, CampaignData data) throws IOException {
         this.binIn(in, data);
     }
 

--- a/MekWarsCommon/src/mekwars/common/PlanetEnvironments.java
+++ b/MekWarsCommon/src/mekwars/common/PlanetEnvironments.java
@@ -38,11 +38,6 @@ import mekwars.common.util.BinWriter;
 public class PlanetEnvironments {
 
     /**
-     * An terrain provider to get terrain information from.
-     */
-    public static transient TerrainProvider data;
-
-    /**
      * The list of all continents. Type=Continent
      */
     private ArrayList<Continent> continents = new ArrayList<Continent>();

--- a/MekWarsCommon/src/mekwars/common/Terrain.java
+++ b/MekWarsCommon/src/mekwars/common/Terrain.java
@@ -18,7 +18,8 @@ package mekwars.common;
 import java.io.IOException;
 import java.util.StringTokenizer;
 import java.util.Vector;
-
+import mekwars.common.entities.Entity;
+import mekwars.common.persistence.EntityStore;
 import mekwars.common.util.BinReader;
 import mekwars.common.util.BinWriter;
 
@@ -26,9 +27,9 @@ import mekwars.common.util.BinWriter;
  * A Terrain Base Terrain container for all environments. Each environment can be a different theme to allow for different times of year.
  */
 
-final public class Terrain {
+final public class Terrain implements Entity {
     // id
-    private int id = -1;
+    private int id = EntityStore.UNSET_ID;
     private String name = "None";
     private Vector<PlanetEnvironment> environments = new Vector<PlanetEnvironment>(10, 1);
 

--- a/MekWarsCommon/src/mekwars/common/entities/Entity.java
+++ b/MekWarsCommon/src/mekwars/common/entities/Entity.java
@@ -1,0 +1,25 @@
+/*
+ * MekWars - Copyright (C) 2025
+ * 
+ * Derived from MegaMekNET (http://www.sourceforge.net/projects/megameknet)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+package mekwars.common.entities;
+
+public interface Entity {
+    int getId();
+
+    void setId(int id);
+
+    String getName();
+}

--- a/MekWarsCommon/src/mekwars/common/persistence/EntityStore.java
+++ b/MekWarsCommon/src/mekwars/common/persistence/EntityStore.java
@@ -1,0 +1,104 @@
+/*
+ * MekWars - Copyright (C) 2025
+ * 
+ * Derived from MegaMekNET (http://www.sourceforge.net/projects/megameknet)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+package mekwars.common.persistence;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import mekwars.common.entities.Entity;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class EntityStore<T extends Entity> {
+    private static final Logger LOGGER = LogManager.getLogger(EntityStore.class);
+
+    public static final int UNSET_ID = -1;
+
+    protected SortedMap<Integer, T> entities = Collections.synchronizedSortedMap(new TreeMap());
+
+    /**
+     * Adds an Entity to the EntityStore.
+     *
+     * @param entity The {@link Entity} to add to the {@link EntityStore}.
+     */
+    public void put(T entity) {
+        LOGGER.info("Adding {}: '{}'", entity.getClass().getSimpleName(), entity.getName());
+
+        if (entity.getId() == UNSET_ID) {
+            entity.setId(nextId());
+        }
+        entities.put(entity.getId(), entity);
+    }
+
+    /**
+     * Gets an entity by their id.
+     *
+     * @param id The id of the {@link Entity} to retrieve.
+     *
+     * @return The {@link Entity} of the given id.
+     */
+    public T get(int id) {
+        return entities.get(id);
+    }
+
+    /**
+     * Removes an entity by their id.
+     *
+     * @param id The id of the {@link Entity} to remove.
+     *
+     * @return The {@link Entity} that is associated with the given id.
+     */
+    public T remove(int id) {
+        return entities.remove(id);
+    }
+
+    /**
+     * Removes all entities from the EntityStore.
+     */
+    public void clear() {
+        entities.clear();
+    }
+
+    /**
+     * Returns a list of all stores entities.
+     *
+     * @return A Collection of all {@link Entity entities}.
+     */
+    public Collection<T> values() {
+        return entities.values();
+    }
+
+    /**
+     * Returns the number of entities in the EntityStore. If the Entity store contains more than
+     * Integer.MAX_VALUE elements, returns Integer.MAX_VALUE.
+     *
+     * @return The number of {@link Entity entities} in this {@link EntityStore}
+     */
+    public int size() {
+        return entities.size();
+    }
+
+    /**
+     * Returns the next available id free for an entity.
+     *
+     * @return The next available id free for an {@link Entity}.
+     */
+    protected int nextId() {
+        return entities.keySet().stream().max(Integer::compare).orElse(0) + 1;
+    }
+}

--- a/MekWarsCommon/src/mekwars/common/persistence/NamedEntityStore.java
+++ b/MekWarsCommon/src/mekwars/common/persistence/NamedEntityStore.java
@@ -1,0 +1,93 @@
+/*
+ * MekWars - Copyright (C) 2025
+ * 
+ * Derived from MegaMekNET (http://www.sourceforge.net/projects/megameknet)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+package mekwars.common.persistence;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import mekwars.common.entities.Entity;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class NamedEntityStore<T extends Entity> extends EntityStore<T> {
+    private static final Logger LOGGER = LogManager.getLogger(NamedEntityStore.class);
+
+    protected SortedMap<String, Integer> entityNames = Collections.synchronizedSortedMap(new TreeMap());
+
+    /**
+     * Adds an Entity to the EntityStore.
+     *
+     * @param entity The {@link Entity} to add to the {@link EntityStore}.
+     */
+    public void put(T entity) {
+        LOGGER.info("Adding {}: '{}'", entity.getClass().getSimpleName(), entity.getName());
+        if (entity.getId() == UNSET_ID) {
+            entity.setId(nextId());
+        }
+
+        entities.put(entity.getId(), entity);
+        String entityName = entity.getName().toLowerCase();
+        if (entityNames.containsKey(entityName)) {
+            LOGGER.error("Entity {} already exists", entityName);
+            throw new IllegalArgumentException();
+        }
+        entityNames.put(entityName, entity.getId());
+    }
+
+    /**
+     * Gets an entity by their name.
+     *
+     * @param name The name of the {@link Entity} to retrieve.
+     *
+     * @return The {@link Entity} of the given name.
+     */
+    public T getByName(String name) {
+         Integer id = entityNames.get(name.toLowerCase());
+
+         if (id == null) {
+             LOGGER.warn("Unable to find '{}'", name.toLowerCase());
+             return null;
+         }
+         return get(id);
+    }
+
+    /**
+     * Removes an entity by their id.
+     *
+     * @param id The id of the {@link Entity} to remove.
+     *
+     * @return The {@link Entity} that is associated with the given id.
+     */
+    public T remove(int id) {
+        T entity = get(id);
+
+        if (entity == null) {
+            return null;
+        }
+        entityNames.remove(entity.getName().toLowerCase());
+        return entities.remove(id);
+    }
+
+    /**
+     * Removes all entities from the EntityStore.
+     */
+    public void clear() {
+        super.clear();
+        entityNames.clear();
+    }
+}

--- a/MekWarsCommon/unittests/mekwars/common/CampaignDataTest.java
+++ b/MekWarsCommon/unittests/mekwars/common/CampaignDataTest.java
@@ -1,0 +1,58 @@
+/*
+ * MekWars - Copyright (C) 2025
+ * 
+ * Derived from MegaMekNET (http://www.sourceforge.net/projects/megameknet)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+package mekwars.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import mekwars.common.persistence.EntityStore;
+import mekwars.common.util.Position;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.Mock;
+
+@ExtendWith(value = MockitoExtension.class)
+class CampaignDataTest {
+    @Mock
+    private Position position;
+
+    @Mock
+    private Influences influence;
+
+    private CampaignData data = new CampaignData();
+
+    @Test
+    public void testAddPlanet() {
+        Planet testPlanet = new Planet("TestPlanet1", position, influence);
+        
+        assertEquals(EntityStore.UNSET_ID, testPlanet.getId());
+        data.addPlanet(testPlanet);
+        assertEquals(1, testPlanet.getId());
+    }
+
+    @Test
+    public void testAddHouse() {
+        House testHouse = new House();
+        
+        assertEquals(EntityStore.UNSET_ID, testHouse.getId());
+        data.addHouse(testHouse);
+        assertEquals(1, testHouse.getId());
+    }
+}

--- a/MekWarsCommon/unittests/mekwars/common/PlanetTest.java
+++ b/MekWarsCommon/unittests/mekwars/common/PlanetTest.java
@@ -1,0 +1,45 @@
+/*
+ * MekWars - Copyright (C) 2025
+ * 
+ * Derived from MegaMekNET (http://www.sourceforge.net/projects/megameknet)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+package mekwars.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import mekwars.common.persistence.EntityStore;
+import mekwars.common.util.Position;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.Mock;
+
+@ExtendWith(value = MockitoExtension.class)
+class PlanetTest {
+    @Mock
+    private Position position;
+
+    @Mock
+    private Influences influence;
+
+    @Test
+    public void testId() {
+        Planet testPlanet = new Planet("TestPlanet1", position, influence);
+        
+        assertEquals(EntityStore.UNSET_ID, testPlanet.getId());
+    }
+}

--- a/MekWarsServer/src/mekwars/server/campaign/CampaignMain.java
+++ b/MekWarsServer/src/mekwars/server/campaign/CampaignMain.java
@@ -240,8 +240,6 @@ public final class CampaignMain implements Serializable {
         partsmarket = new PartsMarket();
         SPilotSkills.initializePilotSkills();
 
-        // Load & Init Data
-        data = new CampaignData();
         xstream = new SMMNetXStream();
 
         // load megamek gameoptions;
@@ -1751,15 +1749,11 @@ public final class CampaignMain implements Serializable {
     }
 
     public void addPlanet(SPlanet p) {
-
-        if (p.getOriginalOwner().trim().equals("")) {
+        if (p.getOriginalOwner().isEmpty()) {
             if (p.getOwner() == null) {
                 p.setOriginalOwner(cm.getConfig("NewbieHouseName"));
             }
             p.setOriginalOwner(p.getOwner().getName());
-        }
-        if (CampaignData.cd.getPlanet(p.getId()) != null) {
-            LOGGER.error("Duplicate Planet ID: " + CampaignData.cd.getPlanet(p.getId()).getName()  + " and " + p.getName());
         }
         data.addPlanet(p);
     }
@@ -2404,16 +2398,6 @@ public final class CampaignMain implements Serializable {
 
     public SHouse getHouseFromPartialString(String HouseString) {
         return getHouseFromPartialString(HouseString, null);
-    }
-
-    public SHouse getHouseFromDBID(int DBId) {
-        for (House currH : data.getAllHouses()) {
-            SHouse sh = (SHouse) currH;
-            if (sh.getDBId() == DBId) {
-                return sh;
-            }
-        }
-        return null;
     }
 
     public SHouse getHouseById(int id) {
@@ -3510,6 +3494,10 @@ public final class CampaignMain implements Serializable {
         // Check for new faction save location
         if (!factionFile.exists() || factionFile.listFiles().length < 1) {
             if (data.getAllHouses().size() == 0) {
+                SHouse none = new MercHouse();
+                none.createNoneHouse();
+                addHouse(none);
+                
                 try {
                     factionFile = new File("./data/factions.xml");
                     SHouse[] factionList = (SHouse[]) getXStream().fromXML(factionFile);
@@ -3525,9 +3513,6 @@ public final class CampaignMain implements Serializable {
                 // Add the Newbie-SHouse
                 SHouse solaris = new NewbieHouse(CampaignMain.cm.getConfig("NewbieHouseName"), "#33CCCC", 4, 5, "SOL");
                 addHouse(solaris);
-                SHouse none = new MercHouse();
-                none.createNoneHouse();
-                addHouse(none);
             }
             return;
         }
@@ -3564,13 +3549,6 @@ public final class CampaignMain implements Serializable {
                 LOGGER.error("Unable to load " + faction.getName());
             }
         }
-
-        if (data.getHouse(-1) == null) {
-            SHouse none = new MercHouse();
-            none.createNoneHouse();
-            addHouse(none);
-        }
-
         // load the various construction modifiers for the houses added above
         factionFile = new File("./campaign/costmodifiers");
         if (!factionFile.exists()) {

--- a/MekWarsServer/src/mekwars/server/campaign/SHouse.java
+++ b/MekWarsServer/src/mekwars/server/campaign/SHouse.java
@@ -2894,7 +2894,6 @@ public class SHouse extends TimeUpdateHouse implements Comparable<Object>, ISell
 
     public void createNoneHouse() {
         setName("None");
-        setId(-1);
         setConquerable(false);
         setHouseDefectionTo(false);
         setHouseDefectionFrom(false);

--- a/MekWarsServer/src/mekwars/server/campaign/SPlanet.java
+++ b/MekWarsServer/src/mekwars/server/campaign/SPlanet.java
@@ -214,11 +214,8 @@ public class SPlanet extends TimeUpdatePlanet implements Serializable, Comparabl
         }
 
         int id = TokenReader.readInt(ST);
-        if (id == -1) {
-        	id = CampaignData.cd.getUnusedPlanetID();
-        }
         setId(id);
-       setMinPlanetOwnerShip(TokenReader.readInt(ST));
+        setMinPlanetOwnerShip(TokenReader.readInt(ST));
 
         setHomeWorld(TokenReader.readBoolean(ST));
 


### PR DESCRIPTION
`NamedEntityStore` and `EntityStore` look like they might more be temporary classes used until we can switch to SQL. I've realized its possible we could also use SQLite on the frontend so theres no need for the client/server to have divergent code for them. It would also get messy as the `EntityStore` is essentially an ORM layer so if you need to get a Player's mech or something the player `EntityStore` would have to have code to handle that.