### PR TITLE
Fetch the correct file for campaignconfig.txt on the client

### DIFF
--- a/MekWarsClient/src/mekwars/client/io/FileSystem.java
+++ b/MekWarsClient/src/mekwars/client/io/FileSystem.java
@@ -17,18 +17,13 @@
 
 package mekwars.client.io;
 
-import java.io.IOException;
-import java.lang.IllegalArgumentException;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import mekwars.common.campaign.clientutils.IClientConfig;
-import mekwars.common.util.IOUtil;
-import mekwars.common.io.FileChecksum;
 import mekwars.common.io.AbstractFileSystem;
 
 public class FileSystem extends AbstractFileSystem {
     private Path configDir;
-    private Path campaignConfig;
 
     private static final String DIRECTORY_NAME_SERVERS = DIRECTORY_NAME_DATA + "servers/";
     private static final Path DIRECTORY_SERVERS = FileSystems.getDefault()
@@ -64,7 +59,6 @@ public class FileSystem extends AbstractFileSystem {
      */
     public void setConfigDir(String configDir) {
         this.configDir = FileSystems.getDefault().getPath(configDir);
-        this.campaignConfig = FileSystems.getDefault().getPath(configDir, FILE_NAME_CAMPAIGN_CONFIG);
     }
 
     /**
@@ -89,18 +83,11 @@ public class FileSystem extends AbstractFileSystem {
 
         String configDirName = DIRECTORY_NAME_SERVERS + serverIp + "." + serverPort;
         this.configDir = FileSystems.getDefault().getPath(configDirName);
-        this.campaignConfig = FileSystems.getDefault().getPath(
-            configDir.getFileName().toString(),
-            config.getParam("CAMPAIGNCONFIG")
-        );
+        calculateChecksums();
     }
 
     public Path getConfigDir() {
         return configDir;
-    }
-
-    public Path getCampaignConfig() {
-        return campaignConfig;
     }
 
     public Path[] getDirectories() {

--- a/MekWarsCommon/src/mekwars/common/io/AbstractFileSystem.java
+++ b/MekWarsCommon/src/mekwars/common/io/AbstractFileSystem.java
@@ -78,7 +78,9 @@ public abstract class AbstractFileSystem {
      *
      * @return The path to the campaignconfig.txt file.
      */
-    public abstract Path getCampaignConfig();
+    public Path getCampaignConfig() {
+        return FileSystems.getDefault().getPath(getConfigDir().toString(), FILE_NAME_CAMPAIGN_CONFIG);
+    }
 
     /**
      * Returns The path to the directory that contains all shared configurations.
@@ -127,6 +129,7 @@ public abstract class AbstractFileSystem {
      * @throws IOException If there is an error in reading one of the files.
      */
     public void calculateChecksums() throws IOException {
+        checksumHash.clear();
         for (Path path : getConfigFiles()) {
             if (getFile(path.getFileName().toString()) == null && Files.exists(path)) {
                 FileChecksum fileChecksum = new FileChecksum(path);

--- a/MekWarsServer/src/mekwars/server/io/FileSystem.java
+++ b/MekWarsServer/src/mekwars/server/io/FileSystem.java
@@ -149,6 +149,7 @@ public class FileSystem extends AbstractFileSystem {
         return DIRECTORY_OPERATIONS_LONG;
     }
 
+    @Override
     public Path getCampaignConfig() {
         return FileSystems.getDefault().getPath(
             getConfigDir().toString(),


### PR DESCRIPTION
This fixes the client's `FileSystem` from incorrectly using the Config to get the campaignconfig.txt's file name. Apparently the filename for that config can only be dynamic on the server side, not the client side. https://github.com/Raugharr/MekWars/blob/c91a333eeb883adf5f646c3c9e6bf5984567b06c/MekWarsClient/src/mekwars/client/protocol/DataFetchClient.java#L90 shows the `DataFetchClient` using the hardcoded filename.

This also changes the `calculateChecksum` method to remove any already computed checksums.