### PR TITLE
Fix user's NAME parameter to late

### DIFF
--- a/MekWarsClient/src/mekwars/client/GUIClient.java
+++ b/MekWarsClient/src/mekwars/client/GUIClient.java
@@ -74,10 +74,10 @@ public class GUIClient {
 
         setupFlatLaf();
         if (shouldAutoconnect) {
+            mwClient.setUsername(config.getParam("NAME"));
             mwClient.connectDataFetcher();
             SplashWindow splashWindow = new SplashWindow(mwClient, getLocale());
             splashWindow.setVisible(true);
-            mwClient.setUsername(config.getParam("NAME"));
         } else if (mwClient.getHpgClient().isConnected()) {
             ServerBrowserDialog serverBrowserDialog = new ServerBrowserDialog(null,
                     locale, mwClient);


### PR DESCRIPTION
Moves setting the NAME parameter earlier so it is set by the time the user connects to the server.