### PR TITLE
Fix distribution being incorrect for the first build

### DIFF
--- a/MekWarsServer/build.gradle
+++ b/MekWarsServer/build.gradle
@@ -81,11 +81,6 @@ task stageFiles(type: Copy) {
         from mmconf
         into "${fileStagingDir}/${mmconf}"
     }
-
-    copy {
-        from "${mmDir}/megamek/build/files/data/mechfiles"
-        into "${fileStagingDir}/data/mechfiles"
-    }
     from "quartz.properties"
     into fileStagingDir
 }
@@ -113,6 +108,7 @@ distributions {
                     .findAll { it.name.endsWith(".jar") }) {
                 into "${lib}"
             }
+            from "${mmDir}/megamek/build/files/data/mechfiles"
             duplicatesStrategy = 'exclude'
         }
     }


### PR DESCRIPTION
The weekly builds are broken, issue is when having a clean install the data files from MegaMek are not getting packaged.