### PR TITLE
Add BanAmmoFile

### DIFF
--- a/MekWarsClient/src/mekwars/admin/dialog/BannedAmmoDialog.java
+++ b/MekWarsClient/src/mekwars/admin/dialog/BannedAmmoDialog.java
@@ -1,6 +1,6 @@
 /*
- * MekWars - Copyright (C) 2004 
- * 
+ * MekWars - Copyright (C) 2004
+ *
  * Derived from MegaMekNET (http://www.sourceforge.net/projects/megameknet)
  * Original author Helge Richter (McWizard)
  *
@@ -17,12 +17,21 @@
 
 package mekwars.admin.dialog;
 
+import megamek.common.AmmoType;
+
+import mekwars.client.MWClient;
+import mekwars.client.common.campaign.clientutils.GameHost;
+import mekwars.common.House;
+import mekwars.common.entities.BannedAmmo;
+import mekwars.common.util.SpringLayoutHelper;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Hashtable;
-import java.util.TreeSet;
+import java.util.Set;
 
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
@@ -33,71 +42,61 @@ import javax.swing.JPanel;
 import javax.swing.JTabbedPane;
 import javax.swing.SpringLayout;
 
-import mekwars.client.MWClient;
-import mekwars.client.common.campaign.clientutils.GameHost;
-import mekwars.common.House;
-import mekwars.common.util.SpringLayoutHelper;
-
-import megamek.common.AmmoType.Munitions;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-public final class BannedAmmoDialog implements ActionListener{
+public final class BannedAmmoDialog implements ActionListener {
     private static final Logger LOGGER = LogManager.getLogger(BannedAmmoDialog.class);
 
-	//store the client backlink for other things to use
-	private MWClient mwclient = null; 
-	private House house = null;
-    
-	private final static String okayCommand = "Add";
-	private final static String cancelCommand = "Close";
+    // store the client backlink for other things to use
+    private MWClient mwclient = null;
+    private House house = null;
 
-	private String windowName = "Server Banned Ammo Editor";	
+    private static final String okayCommand = "Add";
+    private static final String cancelCommand = "Close";
+
+    private String windowName = "Server Banned Ammo Editor";
     private ArrayList<JCheckBox> cBoxArrayList = new ArrayList<JCheckBox>();
-    
-	//BUTTONS
-	private final JButton okayButton = new JButton("Save");
-	private final JButton cancelButton = new JButton("Close");	
-	
-	//STOCK DIALOUG AND PANE
-	private JDialog dialog;
-	private JOptionPane pane;
-	
-	JTabbedPane ConfigPane = new JTabbedPane();
-	
-	public BannedAmmoDialog(MWClient c, House house) {
-		
-		//save the client
-		this.mwclient = c;
-        this.house = house;
-        
-		//stored values.
 
-		//Set the tooltips and actions for dialouge buttons
-		okayButton.setActionCommand(okayCommand);
-		cancelButton.setActionCommand(cancelCommand);
-		
-		okayButton.addActionListener(this);
-		cancelButton.addActionListener(this);
-		okayButton.setToolTipText("Save");
+    // BUTTONS
+    private final JButton okayButton = new JButton("Save");
+    private final JButton cancelButton = new JButton("Close");
+
+    // STOCK DIALOUG AND PANE
+    private JDialog dialog;
+    private JOptionPane pane;
+
+    JTabbedPane ConfigPane = new JTabbedPane();
+
+    public BannedAmmoDialog(MWClient c, House house) {
+
+        // save the client
+        this.mwclient = c;
+        this.house = house;
+
+        // stored values.
+
+        // Set the tooltips and actions for dialouge buttons
+        okayButton.setActionCommand(okayCommand);
+        cancelButton.setActionCommand(cancelCommand);
+
+        okayButton.addActionListener(this);
+        cancelButton.addActionListener(this);
+        okayButton.setToolTipText("Save");
         cancelButton.setToolTipText("Exit without saving changes");
-		
-		
-		//CREATE THE PANELS
-		JPanel banPanel = new JPanel();//player name, etc
-		
-		/*
-		 * Format the Reward Points panel. Spring layout.
-		 */
-		banPanel.setLayout(new BoxLayout(banPanel,BoxLayout.Y_AXIS));
-		
-		JPanel ammoPanel = new JPanel(new SpringLayout());
-		
-        loadBannedAmmo();
-        
-        TreeSet<String> munitions = new TreeSet<String>(mwclient.getData().getMunitionsByName().keySet());
-        for ( String munitionName : munitions){
-            //String munitionName = munitionNames.nextElement();
+
+        // CREATE THE PANELS
+        JPanel banPanel = new JPanel(); // player name, etc
+
+        /*
+         * Format the Reward Points panel. Spring layout.
+         */
+        banPanel.setLayout(new BoxLayout(banPanel, BoxLayout.Y_AXIS));
+
+        JPanel ammoPanel = new JPanel(new SpringLayout());
+
+        mwclient.loadBannedAmmo();
+
+        Set<String> munitions = BannedAmmo.getAllMunitions();
+        for (String munitionName : munitions) {
+            // String munitionName = munitionNames.nextElement();
             JCheckBox cBox = new JCheckBox();
             cBox.setText(munitionName);
             cBox.setSelected(checkAmmoBan(munitionName));
@@ -105,94 +104,76 @@ public final class BannedAmmoDialog implements ActionListener{
             cBoxArrayList.add(cBox);
         }
 
-        SpringLayoutHelper.setupSpringGrid(ammoPanel,2);
+        SpringLayoutHelper.setupSpringGrid(ammoPanel, 2);
 
         banPanel.add(ammoPanel);
-        
+
         // Set the user's options
-		Object[] options = { okayButton, cancelButton };
-		
-		// Create the pane containing the buttons
-		pane = new JOptionPane(banPanel,JOptionPane.PLAIN_MESSAGE,JOptionPane.DEFAULT_OPTION, null, options, null);
-		
-        if ( house != null  )
-            windowName = this.house.getName() +" Banned Ammo Dialog";
-		// Create the main dialog and set the default button
-		dialog = pane.createDialog(ammoPanel, windowName);
-		dialog.getRootPane().setDefaultButton(cancelButton);
+        Object[] options = {okayButton, cancelButton};
 
+        // Create the pane containing the buttons
+        pane =
+                new JOptionPane(
+                        banPanel,
+                        JOptionPane.PLAIN_MESSAGE,
+                        JOptionPane.DEFAULT_OPTION,
+                        null,
+                        options,
+                        null);
 
-		//Show the dialog and get the user's input
-		dialog.setModal(true);
-		dialog.pack();
-		dialog.setVisible(true);
-		
-	}
+        if (house != null) windowName = this.house.getName() + " Banned Ammo Dialog";
+        // Create the main dialog and set the default button
+        dialog = pane.createDialog(ammoPanel, windowName);
+        dialog.getRootPane().setDefaultButton(cancelButton);
 
-	public void actionPerformed(ActionEvent e) {
-		String command = e.getActionCommand();
-        HashMap<String, Munitions> munitionTypes = mwclient.getData().getMunitionsByName();
-        
-        if (command.equals(okayCommand)) {
-            if (house == null) {
-                HashMap<String,String> bannedAmmo = mwclient.getData().getServerBannedAmmo();
-                for (JCheckBox tempBox : cBoxArrayList) {
-                    Munitions ammo = munitionTypes.get(tempBox.getText());
-                    
-                    //Check box has been selected and should be updated to the server
-                    if (tempBox.isSelected() && !bannedAmmo.containsKey(ammo)
-                        || !tempBox.isSelected() && bannedAmmo.containsKey(ammo)) {
-                        mwclient.sendChat(GameHost.CAMPAIGN_PREFIX + "c adminsetserverammoban#"
-                        + munitionTypes.get(tempBox.getText()).ordinal());
-                    }
-                }
-			} else {
-                Hashtable<String, String> bannedAmmo = house.getBannedAmmo();
-                for (JCheckBox tempBox : cBoxArrayList) {
-                    Munitions ammo = munitionTypes.get(tempBox.getText());
-                    
-                    //Check box has been selected and should be updated to the server
-                    //Checkbox has been unselected and should be updated to the server
-                    if (tempBox.isSelected() && !bannedAmmo.containsKey(ammo)
-                            || !tempBox.isSelected() && bannedAmmo.containsKey(ammo)) {
-                        mwclient.sendChat(GameHost.CAMPAIGN_PREFIX + "c adminsethouseammoban#"
-                                +house.getName()+"#"+ munitionTypes.get(tempBox.getText()).ordinal());
-                    }
-                    
-                }
-            }
-            dialog.dispose();
-            return;
-        }
-        else if (command.equals(cancelCommand)) {
-            dialog.dispose();
-		}
-
-	}
-	
-    public void loadBannedAmmo() {
-        mwclient.loadBannedAmmo();
+        // Show the dialog and get the user's input
+        dialog.setModal(true);
+        dialog.pack();
+        dialog.setVisible(true);
     }
-    
-	/*
-	 * @return false if the ammo is banned by the player's house or the server, otherwise true.
-	 */
-    public boolean checkAmmoBan(String ammo){
-        if (house == null) {
-            try {
-                Munitions munition = mwclient.getData().getMunitionsByName().get(ammo);
-                return mwclient.getData().getServerBannedAmmo().containsKey(String.valueOf(munition.ordinal()));
-            } catch (Exception ex) {
-                LOGGER.error("Unable to find ammo " + ammo);
-                return false;
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        String command = e.getActionCommand();
+
+        if (command.equals(okayCommand)) {
+            for (JCheckBox tempBox : cBoxArrayList) {
+                AmmoType.Munitions munitionType = BannedAmmo.getMunitionByName(tempBox.getText());
+                BannedAmmo bannedAmmo =
+                        mwclient.getData().getBannedAmmoStore().get(munitionType, house);
+
+                if (tempBox.isSelected() != (bannedAmmo != null)) {
+                    if (house == null) {
+                        mwclient.sendChat(
+                                GameHost.CAMPAIGN_PREFIX
+                                        + "c adminsetserverammoban#"
+                                        + munitionType.ordinal());
+                    } else {
+                        mwclient.sendChat(
+                                GameHost.CAMPAIGN_PREFIX
+                                        + "c adminsethouseammoban#"
+                                        + house.getName()
+                                        + "#"
+                                        + munitionType.ordinal());
+                    }
+                }
             }
+            dialog.dispose();
+        } else if (command.equals(cancelCommand)) {
+            dialog.dispose();
         }
+    }
+
+    /**
+     * @return false if the ammo is banned by the player's house or the server, otherwise true.
+     */
+    public boolean checkAmmoBan(String ammo) {
         try {
-            Munitions munition = mwclient.getData().getMunitionsByName().get(ammo);
-            return house.getBannedAmmo().containsKey(String.valueOf(munition.ordinal()));
+            AmmoType.Munitions munitionType = BannedAmmo.getMunitionByName(ammo);
+            return mwclient.getData().getBannedAmmoStore().get(munitionType, house) != null;
         } catch (Exception ex) {
             LOGGER.error("Unable to find ammo " + ammo);
             return false;
         }
     }
-}//end BannedAmmoDialog.java
+} // end BannedAmmoDialog.java

--- a/MekWarsClient/src/mekwars/client/MWClient.java
+++ b/MekWarsClient/src/mekwars/client/MWClient.java
@@ -856,7 +856,6 @@ public final class MWClient extends GameHost implements IClient {
     public void processIncoming(String incoming) {
         IProtCommand pcommand = null;
 
-        // LOGGER.info("INCOMING: " + incoming);
         if (incoming.startsWith(IClient.PROTOCOL_PREFIX)) {
             incoming = incoming.substring(IClient.PROTOCOL_PREFIX.length());
             StringTokenizer ST = new StringTokenizer(incoming,
@@ -1313,18 +1312,6 @@ public final class MWClient extends GameHost implements IClient {
                 dataFetcher.store();
                 LOGGER.info("cache data loaded");
                 // Lets start the repair thread
-                if (Boolean.parseBoolean(getServerConfigs("UseAdvanceRepair"))) {
-                    RMT = new RepairManagmentThread(
-                            Long.parseLong(getServerConfigs("TimeForEachRepairPoint")) * 1000,
-                            this);
-                    RMT.start();
-                }
-                if (Boolean.parseBoolean(getServerConfigs("UsePartsRepair"))) {
-                    SMT = new SalvageManagmentThread(
-                            Long.parseLong(getServerConfigs("TimeForEachRepairPoint")) * 1000,
-                            this);
-                    SMT.start();
-                }
             } catch (Throwable e) {
 
                 if (!(e instanceof FileNotFoundException)) {
@@ -1370,6 +1357,18 @@ public final class MWClient extends GameHost implements IClient {
 
             try {
                 dataFetcher.getServerConfigData(this);
+                if (Boolean.parseBoolean(getServerConfigs("UseAdvanceRepair"))) {
+                    RMT = new RepairManagmentThread(
+                            Long.parseLong(getServerConfigs("TimeForEachRepairPoint")) * 1000,
+                            this);
+                    RMT.start();
+                }
+                if (Boolean.parseBoolean(getServerConfigs("UsePartsRepair"))) {
+                    SMT = new SalvageManagmentThread(
+                            Long.parseLong(getServerConfigs("TimeForEachRepairPoint")) * 1000,
+                            this);
+                    SMT.start();
+                }
             } catch (Exception ex) {
                 LOGGER.error("Unable to fetch Server configs.");
                 LOGGER.catching(ex);
@@ -1600,14 +1599,6 @@ public final class MWClient extends GameHost implements IClient {
         return saveFile;
     }
 
-    public void clearBanAmmo() {
-        getData().getServerBannedAmmo().clear();
-
-        for (House faction : getData().getAllHouses()) {
-            faction.getBannedAmmo().clear();
-        }
-    }
-
     public void clearBanTargeting() {
         getData().getBannedTargetingSystems().clear();
     }
@@ -1633,73 +1624,6 @@ public final class MWClient extends GameHost implements IClient {
             p.close();
             out.close();
         } catch (Exception ex) {
-        }
-    }
-
-    public void loadBanAmmo(String line) {
-
-        try {
-            StringTokenizer st = new StringTokenizer(line, "#");
-            String HouseName = (String) st.nextElement();
-            House faction = null;
-            if (!HouseName.equalsIgnoreCase("server")) {
-                faction = getData().getHouseByName(HouseName);
-                while (st.hasMoreTokens()) {
-                    faction.getBannedAmmo().put(st.nextToken(), "Banned");
-                }
-            } else {
-                while (st.hasMoreElements()) {
-                    getData().getServerBannedAmmo().put(st.nextToken(),
-                            "Banned");
-                }
-            }
-        } catch (Exception ex) {
-        }// make it compatible with people that had the old format,without
-         // the timestamp on the first line, the first time and now dont.
-    }
-
-    public void saveBannedAmmo(String timestamp) {
-        // Save banned ammo
-        try {
-
-            // output streams
-            OutputStream out = Files.newOutputStream(FileSystem.getInstance().getBanAmmo());
-            PrintStream p = new PrintStream(out);
-
-            // timestamp
-            p.println(timestamp);
-
-            // server-wide bans
-            p.print("server#");
-            for (String currBan : data.getServerBannedAmmo().keySet()) {
-                p.print(currBan);
-                p.print("#");
-            }
-
-            p.println();// newline
-
-            // faction-only bans
-            for (House h : data.getAllHouses()) {
-
-                if (h.getBannedAmmo().size() < 1) {
-                    continue;
-                }
-
-                p.print(h.getName() + "#");
-                for (String currBan : h.getBannedAmmo().keySet()) {
-                    p.print(currBan);
-                    p.print("#");
-                }
-
-                p.println();
-            }
-
-            // close streams
-            p.close();
-            out.close();
-
-        } catch (Exception ex) {
-            // TODO: Log error?
         }
     }
 

--- a/MekWarsClient/src/mekwars/client/gui/CMainFrame.java
+++ b/MekWarsClient/src/mekwars/client/gui/CMainFrame.java
@@ -34,6 +34,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.text.DecimalFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.StringTokenizer;
 import java.util.Vector;
 import javax.swing.BoxLayout;
@@ -76,6 +79,7 @@ import mekwars.client.gui.dialog.buildtableviewer.BuildTableViewer;
 import mekwars.common.House;
 import mekwars.common.Unit;
 import mekwars.common.campaign.pilot.Pilot;
+import mekwars.common.entities.BannedAmmo;
 import mekwars.common.util.StringUtils;
 import mekwars.client.gui.dialog.InfluencePointsDialog;
 import mekwars.client.gui.dialog.RewardPointsDialog;
@@ -2797,27 +2801,23 @@ public class CMainFrame extends JFrame {
 
         result.append("</table><br>");
 
-        if (mwclient.getData().getServerBannedAmmo().size() > 0) {
-            result.append("<b><i>Server Banned ammo</b></i><br>");
-            for (String key : mwclient.getData().getServerBannedAmmo().keySet()) {
-                result.append(mwclient.getData().getMunitionsByNumber().get(Long.parseLong(key)) + "<br>");
+        Map<Optional<House>, List<BannedAmmo>> bannedAmmoByHouse =
+            mwclient.getData().getBannedAmmoStore().groupByHouse();
+
+        for (Map.Entry<Optional<House>, List<BannedAmmo>> entry : bannedAmmoByHouse.entrySet()) {
+            Optional<House> house = entry.getKey();
+
+            if (house.isEmpty()) {
+                result.append("<b><i>Server Banned ammo</b></i><br>");
+            } else {
+                result.append("<b><i>House Banned Ammo</b></i><br>");
+            }
+
+            for (BannedAmmo bannedAmmo : entry.getValue()) {
+                result.append(bannedAmmo.getName() + "<br>");
             }
         }
 
-        House faction = mwclient.getData().getHouseByName(mwclient.getPlayer().getHouse());
-        if (faction.getBannedAmmo().size() > 0) {
-            result.append("<b><i>House Banned Ammo</b></i><br>");
-            for (String key : faction.getBannedAmmo().keySet()) {
-                result.append(mwclient.getData().getMunitionsByNumber().get(Long.parseLong(key)) + "<br>");
-            }
-        }
-
-        /*
-         * for ( Object prop : System.getProperties().keySet()){
-         * result.append(prop.toString()); result.append(" = ");
-         * result.append(System.getProperty(prop.toString()));
-         * result.append("<br>"); }
-         */
         /*
          * use process incoming, instead of adding directly to misc, so that
          * output is directly to main if misc in main is enabled or players has

--- a/MekWarsClient/src/mekwars/client/gui/dialog/AdvancedRepairDialog.java
+++ b/MekWarsClient/src/mekwars/client/gui/dialog/AdvancedRepairDialog.java
@@ -384,11 +384,10 @@ public class AdvancedRepairDialog extends JFrame implements ActionListener, Mous
                                                                                                                     // ==
                                                                                                                     // atCheck.getTechLevel());
 
-                            EnumSet<Munitions> munition = atCheck.getMunitionType();
                             House faction = mwclient.getData().getHouseByName(mwclient.getPlayer().getHouse());
 
                             // check banned ammo
-                            if (mwclient.getData().getServerBannedAmmo().containsKey(munition) || faction.getBannedAmmo().containsKey(munition)) {
+                            if (mwclient.getData().getBannedAmmoStore().isBanned(atCheck.getMunitionType(), faction)) {
                                 continue;
                             }
 

--- a/MekWarsClient/src/mekwars/client/gui/dialog/CustomUnitDialog.java
+++ b/MekWarsClient/src/mekwars/client/gui/dialog/CustomUnitDialog.java
@@ -36,9 +36,7 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.util.Arrays;
 import java.util.Enumeration;
-import java.util.Iterator;
 import java.util.Vector;
-import java.util.EnumSet;
 
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
@@ -144,7 +142,7 @@ public class CustomUnitDialog extends JDialog implements ActionListener {
         this.unit = unit;
         usingCrits = Boolean.parseBoolean(mwclient.getServerConfigs("UsePartsRepair"));
 
-        if(entity instanceof Aero) {
+        if (entity instanceof Aero) {
             unitIsAero = true;
         }
 
@@ -152,7 +150,7 @@ public class CustomUnitDialog extends JDialog implements ActionListener {
         setTitle("Customize Unit");
 
         // refresh all ammo data
-        loadAmmo();
+        mwclient.loadBannedAmmo();
 
         /*
          * Dialog Layout.
@@ -320,7 +318,6 @@ public class CustomUnitDialog extends JDialog implements ActionListener {
          * Loop through all ammo?
          */
         for (Mounted m : entity.getAmmo()) {
-
             AmmoType at = (AmmoType) m.getType();
             
             Vector<AmmoType> vTypes = new Vector<AmmoType>(1, 1);
@@ -357,33 +354,14 @@ public class CustomUnitDialog extends JDialog implements ActionListener {
                 
                 //boolean bTechMatch = TechConstants.isLegal(entity.getTechLevel(), atCheck.getTechLevel(year), true);// (entity.getTechLevel()
                 
-//                LOGGER.debug("Checking " + atCheck.getInternalName());
-//                LOGGER.debug("BtechMatch: " + bTechMatch);
-//                LOGGER.debug("Year: " + year);
-//                LOGGER.debug("Legal Level: " + legalLevel);
-//                LOGGER.debug("Ammo Tech Level: " + atCheck.getTechLevel(year));
-//                LOGGER.debug("Game Tech Level: " + mmClient.getGame().getOptions().stringOption("techlevel"));
-               
-                // ==
-                // atCheck.getTechLevel());
-                EnumSet<Munitions> munition = atCheck.getMunitionType();
                 House faction = mwclient.getData().getHouseByName(mwclient.getPlayer().getHouse());
 
-                // LOGGER.error("Ammo: "+atCheck.getInternalName()+" MType: "+atCheck.getMunitionType());
-                // check banned ammo
-                if (mwclient.getData().getServerBannedAmmo().containsKey(munition) || faction.getBannedAmmo().containsKey(munition) || ((mwclient.getAmmoCost(atCheck.getInternalName()) < 0) && !usingCrits)) {
-                    //if(mwclient.getData().getServerBannedAmmo().containsKey(munition))
-                        //LOGGER.debug("Banned at the server level");
-                    //if(faction.getBannedAmmo().containsKey(munition))
-                        //LOGGER.debug("Banned at the Faction level");
-                    //LOGGER.debug("Ammo cost: " + mwclient.getAmmoCost(atCheck.getInternalName()));
+                if (mwclient.getData().getBannedAmmoStore().isBanned(atCheck.getMunitionType(), faction) || ((mwclient.getAmmoCost(atCheck.getInternalName()) < 0) && !usingCrits)) {
                     continue;
                 }
 
                 if (usingCrits && (mwclient.getPlayer().getPartsCache().getPartsCritCount(atCheck.getInternalName()) < 1) && !ammoAlreadyLoaded(atCheck) && (// !mwclient.getPlayer().getAutoReorder()
-                        // &&
                         mwclient.getBlackMarketEquipmentList().get(atCheck.getInternalName()) == null)) {
-                    //LOGGER.debug("Player out of ammo.");
                     continue;
                 }
 
@@ -393,13 +371,10 @@ public class CustomUnitDialog extends JDialog implements ActionListener {
                 // need to show up in this display.
                 if (!bTechMatch && ((entity.getTechLevel() == TechConstants.T_IS_ADVANCED) || (entity.getTechLevel() == TechConstants.T_IS_EXPERIMENTAL)) && (atCheck.getTechLevel(year) <= TechConstants.T_IS_TW_NON_BOX)) {
                     bTechMatch = true;
-                    //LOGGER.debug("bTechMatch now true, because all L2 units can use L1 ammo");
                 }
 
                 // if is_eq_limits is unchecked allow L1 units to use L2
                 // munitions
-//                LOGGER.debug("Entity Tech Level: " + entity.getTechLevel());
-//                LOGGER.debug("Ammo tech level: " + atCheck.getTechLevel(year));
 //                if (!entity.isClan() && entity.getTechLevel() == TechConstants.T_INTRO_BOXSET && (atCheck.getTechLevel(year) == TechConstants.T_IS_TW_NON_BOX || atCheck.getTechLevel(year) == TechConstants.T_IS_ADVANCED)) {
 //                    bTechMatch = true;
 //                    LOGGER.debug("bTechMatch is true, because I said so");
@@ -928,12 +903,7 @@ public class CustomUnitDialog extends JDialog implements ActionListener {
         setVisible(false);
     }
 
-    private void loadAmmo() {
-        mwclient.loadBannedAmmo();
-    }
-
     private boolean ammoAlreadyLoaded(AmmoType ammo) {
-
         for (Mounted mounted : entity.getAmmo()) {
             AmmoType currAmmo = (AmmoType) mounted.getType();
 

--- a/MekWarsClient/src/mekwars/client/io/FileSystem.java
+++ b/MekWarsClient/src/mekwars/client/io/FileSystem.java
@@ -92,6 +92,7 @@ public class FileSystem extends AbstractFileSystem {
         calculateChecksums();
     }
 
+    @Override
     public Path getConfigDir() {
         return configDir;
     }

--- a/MekWarsClient/src/mekwars/client/protocol/DataFetchClient.java
+++ b/MekWarsClient/src/mekwars/client/protocol/DataFetchClient.java
@@ -17,9 +17,8 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-
 import javax.swing.JOptionPane;
-
+import megamek.Version;
 import mekwars.client.MWClient;
 import mekwars.client.gui.CMainFrame;
 import mekwars.client.io.FileSystem;
@@ -28,9 +27,9 @@ import mekwars.common.Equipment;
 import mekwars.common.House;
 import mekwars.common.Influences;
 import mekwars.common.Planet;
+import mekwars.common.io.file.BanAmmoFile;
 import mekwars.common.util.BinReader;
 import mekwars.common.util.BinWriter;
-import megamek.Version;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -43,7 +42,7 @@ import org.apache.logging.log4j.Logger;
 public class DataFetchClient {
     private static final Logger LOGGER = LogManager.getLogger(DataFetchClient.class);
 
-	private String hostAddr;
+    private String hostAddr;
     private String cacheDir;
     private CampaignData data;
     private Map<Integer, Influences> changesSinceLastRefresh;
@@ -235,16 +234,15 @@ public class DataFetchClient {
      *
      */
     public void getBannedAmmoData(MWClient mwclient) throws IOException {
-
         boolean timestampMatch = false;
-        File localban = FileSystem.getInstance().getBanAmmo().toFile();
-        if (localban.exists()) {
+        BanAmmoFile banAmmoFile = FileSystem.getInstance().getBanAmmoFile();
+        if (banAmmoFile.getPath().toFile().exists()) {
 
             // get the local timetamp
             String localListTimestamp = "";
 
             try {
-                FileInputStream in = new FileInputStream(localban);
+                FileInputStream in = new FileInputStream(banAmmoFile.getPath().toFile());
                 BufferedReader br = new BufferedReader(new InputStreamReader(in));
                 localListTimestamp = br.readLine();
                 br.close();
@@ -264,33 +262,21 @@ public class DataFetchClient {
         }
 
         // clear the hash so we can add all the new stuff --Torren
-        mwclient.clearBanAmmo();
+        data.getBannedAmmoStore().clear();
         if (!timestampMatch) {
             BinReader in = openConnection("BannedAmmo");
             String timestamp = "-1";
             try {
-                timestamp = in.readLine("BannedAmmo");// TIMESTAMP
+                timestamp = in.readLine("BannedAmmo"); // TIMESTAMP
                 while (true) {
-                    mwclient.loadBanAmmo(in.readLine("BannedAmmo"));
+                    banAmmoFile.loadLine(in.readLine("BannedAmmo"), mwclient.getData());
                 }
-            } catch (Exception ex) {
-            }// Bin empty
-            mwclient.saveBannedAmmo(timestamp);
-        } else {// load from the banned file.
-            try {
-                FileInputStream fis = new FileInputStream(FileSystem.getInstance().getBanAmmo().toString());
-                BufferedReader dis = new BufferedReader(new InputStreamReader(fis));
-                while (dis.ready()) {
-                    String line = dis.readLine();
-                    mwclient.loadBanAmmo(line);
-                }
-                dis.close();
-                fis.close();
             } catch (Exception ex) {
                 LOGGER.error("Exception: ", ex);
-            }
+            } // Bin empty
+            banAmmoFile.save(Long.parseLong(timestamp), mwclient.getData());
         }
-
+        FileSystem.getInstance().getBanAmmoFile().load(mwclient.getData());
     }
 
     /**

--- a/MekWarsCommon/src/mekwars/common/CampaignData.java
+++ b/MekWarsCommon/src/mekwars/common/CampaignData.java
@@ -1,6 +1,6 @@
 /*
- * MekWars - Copyright (C) 2004 
- * 
+ * MekWars - Copyright (C) 2004
+ *
  * Derived from MegaMekNET (http://www.sourceforge.net/projects/megameknet)
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -16,6 +16,15 @@
 
 package mekwars.common;
 
+import megamek.common.AmmoType;
+import mekwars.common.persistence.BannedAmmoStore;
+import mekwars.common.persistence.NamedEntityStore;
+import mekwars.common.util.BinReader;
+import mekwars.common.util.BinWriter;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -25,26 +34,17 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.TreeMap;
 import java.util.Vector;
-import megamek.common.AmmoType;
-import mekwars.common.util.BinReader;
-import mekwars.common.util.BinWriter;
-import mekwars.common.persistence.NamedEntityStore;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 /**
- * TODO: It seems, that all operations done here are needed independly of the
- * semantic of the underlying structure. Planets are handled equal to factions
- * and each function is doubled. If this is true, it should be managed in an
- * generic way to reduce code bloat and code replication.
- * Campaign is the base of the data holding classes for client and server. Here
- * all campaign relevant information as Houses, Planets and Player data is
- * stored.
- * In this base class some methods are provided to retrieve these informations
- * to use in common data classes like House or Planet when reffering to
- * ressources.
- * Notice: Please read the doc to binOut before adding new data types.
- * 
+ * TODO: It seems, that all operations done here are needed independly of the semantic of the
+ * underlying structure. Planets are handled equal to factions and each function is doubled. If this
+ * is true, it should be managed in an generic way to reduce code bloat and code replication.
+ * Campaign is the base of the data holding classes for client and server. Here all campaign
+ * relevant information as Houses, Planets and Player data is stored. In this base class some
+ * methods are provided to retrieve these informations to use in common data classes like House or
+ * Planet when reffering to ressources. Notice: Please read the doc to binOut before adding new data
+ * types.
+ *
  * @author Imi (immanuel.scholz@gmx.de)
  */
 public class CampaignData implements TerrainProvider {
@@ -57,21 +57,21 @@ public class CampaignData implements TerrainProvider {
     private NamedEntityStore<Terrain> terrains = new NamedEntityStore<>();
     private NamedEntityStore<AdvancedTerrain> advancedTerrains = new NamedEntityStore<>();
 
-    private HashMap<String, String> ServerBannedAmmo = new HashMap<>();
     private Vector<Integer> bannedTargetingSystems = new Vector<>();
     private HashMap<String, Integer> commands = new HashMap<>();
     private TreeMap<String, String> planetOpFlags = new TreeMap<>();
 
-    private HashMap<String, AmmoType.Munitions> munitionsByName;
-    private HashMap<AmmoType.Munitions, String> munitionsByNumber;
-
+    private BannedAmmoStore bannedAmmoStore = new BannedAmmoStore();
     private Properties serverConfigs = new Properties();
+
+    public BannedAmmoStore getBannedAmmoStore() {
+        return bannedAmmoStore;
+    }
 
     /**
      * Retrieve a specific planet.
-     * 
-     * @param id
-     *            The id of the planet.
+     *
+     * @param id The id of the planet.
      * @return The requested Planet. This is usually a subclass of Planet.
      */
     public Planet getPlanet(int id) {
@@ -79,8 +79,8 @@ public class CampaignData implements TerrainProvider {
     }
 
     /**
-     * Retrieve a planet by its name. Please try to use planet Id's when lookup
-     * for a planet instead (if you have the choice).
+     * Retrieve a planet by its name. Please try to use planet Id's when lookup for a planet instead
+     * (if you have the choice).
      */
     public Planet getPlanetByName(String name) {
         return planets.getByName(name);
@@ -88,7 +88,6 @@ public class CampaignData implements TerrainProvider {
 
     /**
      * @author jtighe Retrieve a factory by its name.
-     * 
      */
     public UnitFactory getFactoryByName(Planet p, String name) {
         for (UnitFactory e : p.getUnitFactories()) {
@@ -99,19 +98,16 @@ public class CampaignData implements TerrainProvider {
         return null;
     }
 
-    /**
-     * Retrieves all planets.
-     */
+    /** Retrieves all planets. */
     public Collection<Planet> getAllPlanets() {
         return planets.values();
     }
 
     /**
-     * Adds a planet to the campaign storage. If it was already within the
-     * storage, it replaces the old object.
-     * 
-     * @param planet
-     *            The planet to hold.
+     * Adds a planet to the campaign storage. If it was already within the storage, it replaces the
+     * old object.
+     *
+     * @param planet The planet to hold.
      * @see You should use XStream to initialize CampaignData
      */
     public void addPlanet(Planet planet) {
@@ -120,57 +116,47 @@ public class CampaignData implements TerrainProvider {
 
     /**
      * BUMM - Blow up a planet.
-     * 
-     * @param id
-     *            The id of the blown up planet.
+     *
+     * @param id The id of the blown up planet.
      */
     public void removePlanet(int id) {
         planets.remove(id);
     }
 
-    /**
-     * Remove all planets.
-     */
+    /** Remove all planets. */
     public void clearPlanets() {
         planets.clear();
     }
 
     /**
      * Retrieve a specific faction.
-     * 
-     * @param id
-     *            The id of the House.
+     *
+     * @param id The id of the House.
      * @return The requested faction.
      */
     public House getHouse(int ID) {
         return factions.get(ID);
     }
 
-    /**
-     * Retrieves all factions.
-     */
+    /** Retrieves all factions. */
     public Collection<House> getAllHouses() {
         return factions.values();
     }
 
     /**
-     * Adds a faction to the campaign storage. If it was already within the
-     * storage, it replaces the old object.
-     * 
-     * @param planet
-     *            The faction to hold.
-     * @TODO You should use XStream to initialize CampaignData
+     * Adds a faction to the campaign storage. If it was already within the storage, it replaces the
+     * old object.
+     *
+     * @param planet The faction to hold. @TODO You should use XStream to initialize CampaignData
      */
     public void addHouse(House faction) {
         factions.put(faction);
     }
 
     /**
-     * Remove a house from the server this is normally only for single faction
-     * servers
-     * 
-     * @param Integer
-     *            id
+     * Remove a house from the server this is normally only for single faction servers
+     *
+     * @param Integer id
      */
     public void removeHouse(int id) {
         House faction = factions.get(id);
@@ -194,38 +180,34 @@ public class CampaignData implements TerrainProvider {
 
     /**
      * Retrieve a faction by its name.
-     * 
+     *
      * @param name
-     * @return
-     * @TODO This seems to be only needed, because some serialization work with
-     *       transmitting the factions name instead of its id.
+     * @return @TODO This seems to be only needed, because some serialization work with transmitting
+     *     the factions name instead of its id.
      */
     public House getHouseByName(String name) {
         return factions.getByName(name);
     }
 
-    /**
-     * Remove all factions.
-     */
+    /** Remove all factions. */
     public void clearHouses() {
         factions.clear();
     }
 
     /**
-     * Since I have no idea how TinyXML is operating and since McWizard does not
-     * allow me to use my loved JDom and finally since Enkel does not like
-     * XML-Transfer anyway, I use this to encode/decode the whole object.. (Imi)
-     * 
-     * There is another aspect of binOut to keep in mind. Since a MD5 hash is
-     * build after each differential update to keep the data in sync, this
-     * function has to provide THE SAME output each time it is run, regardless
-     * of the underlying virtual machine. Currently this is done by only using
-     * container classes, that remain the elements in a stable order. If you
-     * need to add a container with unstable order (as Hash*), you have to make
-     * sure, the data is odered before writing it out with binOut.
-     * 
-     * TODO: check http://jira.codehaus.org/secure/ViewIssue.jspa?key=XSTR-27 to
-     * see whether a better way of serialization is available ;-)
+     * Since I have no idea how TinyXML is operating and since McWizard does not allow me to use my
+     * loved JDom and finally since Enkel does not like XML-Transfer anyway, I use this to
+     * encode/decode the whole object.. (Imi)
+     *
+     * <p>There is another aspect of binOut to keep in mind. Since a MD5 hash is build after each
+     * differential update to keep the data in sync, this function has to provide THE SAME output
+     * each time it is run, regardless of the underlying virtual machine. Currently this is done by
+     * only using container classes, that remain the elements in a stable order. If you need to add
+     * a container with unstable order (as Hash*), you have to make sure, the data is odered before
+     * writing it out with binOut.
+     *
+     * <p>TODO: check http://jira.codehaus.org/secure/ViewIssue.jspa?key=XSTR-27 to see whether a
+     * better way of serialization is available ;-)
      */
     public void binOut(BinWriter out) throws IOException {
         binTerrainsOut(out);
@@ -235,7 +217,7 @@ public class CampaignData implements TerrainProvider {
 
     /**
      * Outputs all factions
-     * 
+     *
      * @see CampaignData.binOut()
      */
     public void binHousesOut(BinWriter out) throws IOException {
@@ -247,7 +229,7 @@ public class CampaignData implements TerrainProvider {
 
     /**
      * Outputs updated houses
-     * 
+     *
      * @see CampaignData.binOut()
      */
     public void binHousesOut(ArrayList<House> houses, BinWriter out) throws IOException {
@@ -259,7 +241,7 @@ public class CampaignData implements TerrainProvider {
 
     /**
      * Outputs all terrains
-     * 
+     *
      * @see CampaignData.binOut()
      */
     public void binTerrainsOut(BinWriter out) throws IOException {
@@ -271,12 +253,11 @@ public class CampaignData implements TerrainProvider {
         for (AdvancedTerrain pe : advancedTerrains.values()) {
             pe.binOut(out);
         }
-        
     }
 
     /**
      * Outputs all planets
-     * 
+     *
      * @see CampaignData.binOut()
      */
     public void binPlanetsOut(BinWriter out) throws IOException {
@@ -288,7 +269,7 @@ public class CampaignData implements TerrainProvider {
 
     /**
      * Outputs all planets
-     * 
+     *
      * @see CampaignData.binOut()
      */
     public void binPlanetsOut(ArrayList<Planet> planets, BinWriter out) throws IOException {
@@ -298,28 +279,18 @@ public class CampaignData implements TerrainProvider {
         }
     }
 
-    /**
-     * Create empty campaign data.
-     */
+    /** Create empty campaign data. */
     public CampaignData() {
         cd = this;
-        this.munitionsByName = createMunitions();
-        this.munitionsByNumber = new HashMap<>();
-
-        for (Map.Entry<String, AmmoType.Munitions> entry : munitionsByName.entrySet()) {
-            munitionsByNumber.put(entry.getValue(), entry.getKey());
-        }
     }
 
-    /**
-     * Generate the campaign data from an binary stream.
-     */
+    /** Generate the campaign data from an binary stream. */
     public CampaignData(BinReader in) throws IOException {
         this();
         int size = in.readInt("terrains.size");
         for (int i = 0; i < size; ++i) {
             Terrain pe = new Terrain();
-            pe.binIn(in, this);            
+            pe.binIn(in, this);
             addTerrain(pe);
         }
         int Advsize = in.readInt("advTerrains.size");
@@ -391,36 +362,6 @@ public class CampaignData implements TerrainProvider {
         return advancedTerrains.getByName(name);
     }
 
-    /**
-     * @author Torren (Jason Tighe)
-     * 
-     *         this returns a hashtable of all current MM munitions 06/10/05
-     *         using the Name of the munition as the key
-     * @return HashMap
-     */
-    public HashMap<String, AmmoType.Munitions> getMunitionsByName() {
-        return munitionsByName;
-    }
-
-    /**
-     * @author Torren (Jason Tighe)
-     * 
-     *         this returns a hashtable of all current MM munitions 06/10/05
-     *         using the Number of the munition as the key
-     * @return HashMap
-     */
-    public HashMap<AmmoType.Munitions, String> getMunitionsByNumber() {
-        return munitionsByNumber;
-    }
-
-    public void setServerBannedAmmo(HashMap<String, String> ban) {
-        ServerBannedAmmo = ban;
-    }
-
-    public HashMap<String, String> getServerBannedAmmo() {
-        return ServerBannedAmmo;
-    }
-
     public void setBannedTargetingSystems(Vector<Integer> ban) {
         bannedTargetingSystems = ban;
     }
@@ -430,9 +371,8 @@ public class CampaignData implements TerrainProvider {
     }
 
     /**
-     * extracts data from the BinReader and places it into the client side hash
-     * table.
-     * 
+     * extracts data from the BinReader and places it into the client side hash table.
+     *
      * @param in
      * @param userLevel
      */
@@ -488,7 +428,7 @@ public class CampaignData implements TerrainProvider {
         }
         return false;
     }
-    
+
     public House getHouseFromPartialString(String houseString) {
         // store matches so we can tell player if there's more than one
         int numMatches = 0;
@@ -510,79 +450,5 @@ public class CampaignData implements TerrainProvider {
 
         // only one match! send it back.
         return theMatch;
-    }
-
-    /**
-     * Note: This should eventually be swapped out for using some MegaMek native method that probably
-     * exists.
-     *
-     * @return HashMap<String, AmmoType.Munitions>
-     */
-    private HashMap<String, AmmoType.Munitions> createMunitions() {
-        HashMap<String, AmmoType.Munitions> munitions = new HashMap<String, AmmoType.Munitions>();
-
-        munitions.put("Standard", AmmoType.Munitions.M_STANDARD);
-
-        // AC Munition Types
-        munitions.put("Cluster", AmmoType.Munitions.M_CLUSTER);
-        munitions.put("AC Armor Piercing", AmmoType.Munitions.M_ARMOR_PIERCING);
-        munitions.put("AC Flechette", AmmoType.Munitions.M_FLECHETTE);
-        munitions.put("AC Incendiary", AmmoType.Munitions.M_INCENDIARY_AC);
-        munitions.put("AC Precision", AmmoType.Munitions.M_PRECISION);
-        munitions.put("AC Tracer", AmmoType.Munitions.M_TRACER);
-
-        // ATM Munition Types
-        munitions.put("ATM Extended Range", AmmoType.Munitions.M_EXTENDED_RANGE);
-        munitions.put("ATM High Explosive", AmmoType.Munitions.M_HIGH_EXPLOSIVE);
-
-        // LRM & SRM Munition Types
-        munitions.put("LRM/SRM Fragmentation", AmmoType.Munitions.M_FRAGMENTATION);
-        munitions.put("LRM/SRM Listen Kill", AmmoType.Munitions.M_LISTEN_KILL);
-        munitions.put("LRM/SRM Anti-TSM", AmmoType.Munitions.M_ANTI_TSM);
-        munitions.put("LRM/SRM Narc", AmmoType.Munitions.M_NARC_CAPABLE);
-        munitions.put("LRM/SRM Artemis", AmmoType.Munitions.M_ARTEMIS_CAPABLE);
-        munitions.put("LRM/SRM Heat-Seeking", AmmoType.Munitions.M_HEAT_SEEKING);
-        munitions.put("LRM/SRM Dead-Fire", AmmoType.Munitions.M_DEAD_FIRE);
-        munitions.put("LRM/SRM Tandem-Charge", AmmoType.Munitions.M_TANDEM_CHARGE);
-
-        // LRM Munition Types
-        // Incendiary is special, though...
-        munitions.put("LRM Incendiary", AmmoType.Munitions.M_INCENDIARY_LRM);
-        munitions.put("LRM Flare", AmmoType.Munitions.M_FLARE);
-        munitions.put("LRM SemiGuided", AmmoType.Munitions.M_SEMIGUIDED);
-        munitions.put("LRM Swarm", AmmoType.Munitions.M_SWARM);
-        munitions.put("LRM Swarm I", AmmoType.Munitions.M_SWARM_I);
-        munitions.put("LRM Thunder", AmmoType.Munitions.M_THUNDER);
-        munitions.put("LRM Thunder Augmented", AmmoType.Munitions.M_THUNDER_AUGMENTED);
-        munitions.put("LRM Thunder Inferno", AmmoType.Munitions.M_THUNDER_INFERNO);
-        munitions.put("LRM Thunder VibraBomb", AmmoType.Munitions.M_THUNDER_VIBRABOMB);
-        munitions.put("LRM Thunder Active", AmmoType.Munitions.M_THUNDER_ACTIVE);
-        munitions.put("LRM Follow The Leader", AmmoType.Munitions.M_FOLLOW_THE_LEADER);
-        munitions.put("Multi Purpose", AmmoType.Munitions.M_MULTI_PURPOSE);
-
-        // SRM Munition Types
-        munitions.put("SRM Inferno", AmmoType.Munitions.M_INFERNO);
-        munitions.put("SRM Acid", AmmoType.Munitions.M_AX_HEAD);
-
-        // Torps
-        munitions.put("LRT/SRT", AmmoType.Munitions.M_TORPEDO);
-
-        // iNarc Munition Types
-        munitions.put("iNarc Explosive", AmmoType.Munitions.M_EXPLOSIVE);
-        munitions.put("iNarc ECM", AmmoType.Munitions.M_ECM);
-        munitions.put("iNarc HayWire", AmmoType.Munitions.M_HAYWIRE);
-        munitions.put("iNarc Nemesis", AmmoType.Munitions.M_NEMESIS);
-
-        // Narc Munition Types
-        munitions.put("Narc Explosive", AmmoType.Munitions.M_NARC_EX);
-
-        // Arrow IV Munition Types
-        munitions.put("Arrow IV Homing", AmmoType.Munitions.M_HOMING);
-        munitions.put("Arrow IV FASCAM", AmmoType.Munitions.M_FASCAM);
-        munitions.put("Arrow IV Inferno", AmmoType.Munitions.M_INFERNO_IV);
-        munitions.put("Arrow IV VibraBomb", AmmoType.Munitions.M_VIBRABOMB_IV);
-        munitions.put("Arrow IV Smoke", AmmoType.Munitions.M_SMOKE);
-        munitions.put("Arrow IV Davy Crockett", AmmoType.Munitions.M_DAVY_CROCKETT_M);
-        return munitions;
     }
 }

--- a/MekWarsCommon/src/mekwars/common/House.java
+++ b/MekWarsCommon/src/mekwars/common/House.java
@@ -64,7 +64,6 @@ public class House implements Entity {
 
     private boolean conquerable = true;
 
-    private Hashtable<String, String> BannedAmmo = new Hashtable<String, String>();
     private int techLevel = TechConstants.T_ALLOWED_ALL;
     private boolean allowDefectionsFrom = true;
     private boolean allowDefectionsTo = true;
@@ -321,11 +320,6 @@ public class House implements Entity {
             for (int weight = 0; weight < 4; weight++)
                 out.println(this.getHouseUnitFluMod(type, weight), "fluMod" + type + weight);
 
-        out.println(this.getBannedAmmo().size(), "factionbannedammosize");
-        for (String munition : this.getBannedAmmo().keySet()) {
-            out.println(munition, "munition");
-        }
-
         for (int pos = 0; pos < Unit.MAXBUILD; pos++) {
             out.println(basePilotSkills.elementAt(pos), "factionBasePilotSkill");
         }
@@ -397,10 +391,6 @@ public class House implements Entity {
             }
         }
 
-        int size = in.readInt("factionbannedammosize");
-        for (; size > 0; size--)
-            BannedAmmo.put(in.readLine("munition"), "Banned");
-
         for (int pos = 0; pos < Unit.MAXBUILD; pos++) {
             basePilotSkills.set(pos, in.readLine("factionBasePilotSkill"));
         }
@@ -418,7 +408,7 @@ public class House implements Entity {
             this.tags.add(tag); 
         }
 
-        size = in.readInt("subfactionsize");
+        int size = in.readInt("subfactionsize");
 
         this.subFactionList.clear();
         for (; size > 0; size--) {
@@ -448,76 +438,6 @@ public class House implements Entity {
     public void setId(int id) {
         this.id = id;
     }
-
-    /**
-     * @see common.persistence.MMNetSerializable#binOut(common.persistence.TreeWriter)
-     * 
-     * public void binOut(TreeWriter out) {
-     * 
-     * out.write(id.intValue(), "id"); out.write(name, "name"); out.write(logo,
-     * "logo"); out.write(baseGunner, "baseGunner"); out.write(basePilot,
-     * "basePilot"); out.write(factionColor, "factionColor");
-     * 
-     * out.write(factionPlayerColors,"factionPlayerColor");
-     * 
-     * out.write(abbreviation, "abbreviation"); out.write(conquerable,
-     * "conquerable");
-     * 
-     * for ( int type = 0; type < 5; type++ ) for ( int weight = 0; weight < 4;
-     * weight++)
-     * out.write(this.getHouseUnitComponentMod(type,weight),"componentMod"+type+weight);
-     * for ( int type = 0; type < 5; type++ ) for ( int weight = 0; weight < 4;
-     * weight++)
-     * out.write(this.getHouseUnitPriceMod(type,weight),"priceMod"+type+weight);
-     * for ( int type = 0; type < 5; type++ ) for ( int weight = 0; weight < 4;
-     * weight++)
-     * out.write(this.getHouseUnitFluMod(type,weight),"fluMod"+type+weight);
-     * 
-     * out.write(this.getBannedAmmo().size(),"factionbannedammosize"); for
-     * (String banned : this.getBannedAmmo().keySet())
-     * out.write(banned,"munition");
-     * 
-     * for( int pos = 0; pos < Unit.MAXBUILD; pos++ ){
-     * out.write(basePilotSkills.elementAt(pos),"factionBasePilotSkill"); }
-     *  }
-     * 
-     * /**
-     * @see common.persistence.MMNetSerializable#binIn(common.persistence.TreeReader)
-     * 
-     * public void binIn(TreeReader in, CampaignData dataProvider)throws
-     * IOException {
-     * 
-     * for( int pos = 0; pos < Unit.MAXBUILD; pos++ ){ baseGunner.add(4);
-     * basePilot.add(5); basePilotSkills.add(" "); }
-     * 
-     * id = new Integer(in.readInt("id")); name =
-     * HTML.br2cr(in.readString("name")); logo =
-     * HTML.br2cr(in.readString("logo"));
-     * setBaseGunner(in.readInt("baseGunner"));
-     * setBasePilot(in.readInt("basePilot")); factionColor =
-     * in.readString("factionColor");
-     * 
-     * factionPlayerColors = in.readString("factionPlayerColor");
-     * 
-     * abbreviation = in.readString("abbreviation"); conquerable =
-     * in.readBoolean("conquerable");
-     * 
-     * for ( int type = 0; type < 5; type++ ) for ( int weight = 0; weight < 4;
-     * weight++)
-     * this.setHouseUnitComponentMod(type,weight,in.readInt("componentMod"+type+weight));
-     * for ( int type = 0; type < 5; type++ ) for ( int weight = 0; weight < 4;
-     * weight++)
-     * this.setHouseUnitPriceMod(type,weight,in.readInt("priceMod"+type+weight));
-     * for ( int type = 0; type < 5; type++ ) for ( int weight = 0; weight < 4;
-     * weight++)
-     * this.setHouseUnitFluMod(type,weight,in.readInt("fluMod"+type+weight));
-     * 
-     * int size = in.readInt("factionbannedammosize"); for( ; size > 0; size--)
-     * BannedAmmo.put(in.readString("munition"),"Banned");
-     * 
-     * for( int pos = 0; pos < Unit.MAXBUILD; pos++ ){
-     * basePilotSkills.set(pos,in.readString("factionBasePilotSkill")); } }
-     */
 
     /**
      * @get the unit price mod for a faction
@@ -570,14 +490,6 @@ public class House implements Entity {
 
     public String getHousePlayerColor() {
         return this.factionPlayerColors;
-    }
-
-    // public void setBannedAmmo(Hashtable<String,String> ban){
-    // BannedAmmo = ban;
-    // }
-
-    public Hashtable<String, String> getBannedAmmo() {
-        return BannedAmmo;
     }
 
     public void setTechLevel(int level) {
@@ -728,5 +640,9 @@ public class House implements Entity {
 
     public boolean isClan() {
         return is(FactionTag.CLAN);
+    }
+
+    public boolean equals(House house) {
+        return (house != null) && (getId() == house.getId());
     }
 }

--- a/MekWarsCommon/src/mekwars/common/entities/BannedAmmo.java
+++ b/MekWarsCommon/src/mekwars/common/entities/BannedAmmo.java
@@ -1,0 +1,157 @@
+/*
+ * MekWars - Copyright (C) 2026
+ *
+ * Derived from MegaMekNET (http://www.sourceforge.net/projects/megameknet) Original author Helge Richter (McWizard)
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ */
+
+package mekwars.common.entities;
+
+import megamek.common.AmmoType;
+
+import mekwars.common.House;
+
+import java.util.Set;
+import java.util.HashMap;
+import java.util.Map;
+
+public class BannedAmmo implements Entity {
+    private static HashMap<String, AmmoType.Munitions> MUNITIONS_BY_NAME = createMunitionsByName();
+    private static HashMap<AmmoType.Munitions, String> MUNITIONS_BY_NUMBER =
+            createMunitionsByNumber();
+    private static final AmmoType.Munitions[] MUNITION_VALUES = AmmoType.Munitions.values();
+    // If house is null, then the ammo is system banned.
+    private House house;
+    private AmmoType.Munitions munition;
+
+    public BannedAmmo(AmmoType.Munitions munition, House house) {
+        this.munition = munition;
+        this.house = house;
+    }
+
+    public House getHouse() {
+        return house;
+    }
+
+    public AmmoType.Munitions getMunition() {
+        return munition;
+    }
+
+    public int getId() {
+        return munition.ordinal();
+    }
+
+    /**
+     * Does nothing, the Id of a BannedAmmo is based on the ordinal value of the
+     * {@link AmmoType.Munitions}.
+     */
+    public void setId(int id) {}
+
+    public String getName() {
+        return MUNITIONS_BY_NUMBER.get(munition);
+    }
+
+    public static Set<String> getAllMunitions() {
+        return MUNITIONS_BY_NAME.keySet();
+    }
+
+    public static AmmoType.Munitions getMunitionByName(String name) {
+        return MUNITIONS_BY_NAME.get(name);
+    }
+
+    public static AmmoType.Munitions getMunitionByNumber(int id) {
+        if (id >= 0 && id < MUNITION_VALUES.length) {
+            return MUNITION_VALUES[id];
+        }
+        return null;
+    }
+
+    /**
+     * Note: This should eventually be swapped out for using some MegaMek native method that
+     * probably exists.
+     *
+     * @return HashMap<String, AmmoType.Munitions>
+     */
+    private static HashMap<String, AmmoType.Munitions> createMunitionsByName() {
+        HashMap<String, AmmoType.Munitions> munitions =
+                new HashMap<String, AmmoType.Munitions>();
+
+        munitions.put("Standard", AmmoType.Munitions.M_STANDARD);
+
+        // AC Munition Types
+        munitions.put("Cluster", AmmoType.Munitions.M_CLUSTER);
+        munitions.put("AC Armor Piercing", AmmoType.Munitions.M_ARMOR_PIERCING);
+        munitions.put("AC Flechette", AmmoType.Munitions.M_FLECHETTE);
+        munitions.put("AC Incendiary", AmmoType.Munitions.M_INCENDIARY_AC);
+        munitions.put("AC Precision", AmmoType.Munitions.M_PRECISION);
+        munitions.put("AC Tracer", AmmoType.Munitions.M_TRACER);
+
+        // ATM Munition Types
+        munitions.put("ATM Extended Range", AmmoType.Munitions.M_EXTENDED_RANGE);
+        munitions.put("ATM High Explosive", AmmoType.Munitions.M_HIGH_EXPLOSIVE);
+
+        // LRM & SRM Munition Types
+        munitions.put("LRM/SRM Fragmentation", AmmoType.Munitions.M_FRAGMENTATION);
+        munitions.put("LRM/SRM Listen Kill", AmmoType.Munitions.M_LISTEN_KILL);
+        munitions.put("LRM/SRM Anti-TSM", AmmoType.Munitions.M_ANTI_TSM);
+        munitions.put("LRM/SRM Narc", AmmoType.Munitions.M_NARC_CAPABLE);
+        munitions.put("LRM/SRM Artemis", AmmoType.Munitions.M_ARTEMIS_CAPABLE);
+        munitions.put("LRM/SRM Heat-Seeking", AmmoType.Munitions.M_HEAT_SEEKING);
+        munitions.put("LRM/SRM Dead-Fire", AmmoType.Munitions.M_DEAD_FIRE);
+        munitions.put("LRM/SRM Tandem-Charge", AmmoType.Munitions.M_TANDEM_CHARGE);
+
+        // LRM Munition Types
+        // Incendiary is special, though...
+        munitions.put("LRM Incendiary", AmmoType.Munitions.M_INCENDIARY_LRM);
+        munitions.put("LRM Flare", AmmoType.Munitions.M_FLARE);
+        munitions.put("LRM SemiGuided", AmmoType.Munitions.M_SEMIGUIDED);
+        munitions.put("LRM Swarm", AmmoType.Munitions.M_SWARM);
+        munitions.put("LRM Swarm I", AmmoType.Munitions.M_SWARM_I);
+        munitions.put("LRM Thunder", AmmoType.Munitions.M_THUNDER);
+        munitions.put("LRM Thunder Augmented", AmmoType.Munitions.M_THUNDER_AUGMENTED);
+        munitions.put("LRM Thunder Inferno", AmmoType.Munitions.M_THUNDER_INFERNO);
+        munitions.put("LRM Thunder VibraBomb", AmmoType.Munitions.M_THUNDER_VIBRABOMB);
+        munitions.put("LRM Thunder Active", AmmoType.Munitions.M_THUNDER_ACTIVE);
+        munitions.put("LRM Follow The Leader", AmmoType.Munitions.M_FOLLOW_THE_LEADER);
+        munitions.put("Multi Purpose", AmmoType.Munitions.M_MULTI_PURPOSE);
+
+        // SRM Munition Types
+        munitions.put("SRM Inferno", AmmoType.Munitions.M_INFERNO);
+        munitions.put("SRM Acid", AmmoType.Munitions.M_AX_HEAD);
+
+        // Torps
+        munitions.put("LRT/SRT", AmmoType.Munitions.M_TORPEDO);
+
+        // iNarc Munition Types
+        munitions.put("iNarc Explosive", AmmoType.Munitions.M_EXPLOSIVE);
+        munitions.put("iNarc ECM", AmmoType.Munitions.M_ECM);
+        munitions.put("iNarc HayWire", AmmoType.Munitions.M_HAYWIRE);
+        munitions.put("iNarc Nemesis", AmmoType.Munitions.M_NEMESIS);
+
+        // Narc Munition Types
+        munitions.put("Narc Explosive", AmmoType.Munitions.M_NARC_EX);
+
+        // Arrow IV Munition Types
+        munitions.put("Arrow IV Homing", AmmoType.Munitions.M_HOMING);
+        munitions.put("Arrow IV FASCAM", AmmoType.Munitions.M_FASCAM);
+        munitions.put("Arrow IV Inferno", AmmoType.Munitions.M_INFERNO_IV);
+        munitions.put("Arrow IV VibraBomb", AmmoType.Munitions.M_VIBRABOMB_IV);
+        munitions.put("Arrow IV Smoke", AmmoType.Munitions.M_SMOKE);
+        munitions.put("Arrow IV Davy Crockett", AmmoType.Munitions.M_DAVY_CROCKETT_M);
+        return munitions;
+    }
+
+    private static HashMap<AmmoType.Munitions, String> createMunitionsByNumber() {
+        HashMap<AmmoType.Munitions, String> munitionsByNumber = new HashMap<>();
+
+        for (Map.Entry<String, AmmoType.Munitions> entry : createMunitionsByName().entrySet()) {
+            munitionsByNumber.put(entry.getValue(), entry.getKey());
+        }
+        return munitionsByNumber;
+    }
+}

--- a/MekWarsCommon/src/mekwars/common/io/AbstractFileSystem.java
+++ b/MekWarsCommon/src/mekwars/common/io/AbstractFileSystem.java
@@ -23,6 +23,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.ConcurrentHashMap;
 
+import mekwars.common.io.file.BanAmmoFile;
+
 public abstract class AbstractFileSystem {
     public static final String FILE_NAME_CAMPAIGN_CONFIG = "campaignconfig.txt";
     public static final String FILE_NAME_BAN_AMMO = "banammo.dat";
@@ -51,8 +53,17 @@ public abstract class AbstractFileSystem {
      *
      * @return The path to the banammo.dat file.
      */
-    public Path getBanAmmo() {
+    public Path getBanAmmoPath() {
         return FileSystems.getDefault().getPath(getConfigDir().toString(), FILE_NAME_BAN_AMMO);
+    }
+
+    /**
+     * Returns am instance of BanAmmoFile.
+     *
+     * @return An instance of BanAmmoFile.
+     */
+    public BanAmmoFile getBanAmmoFile() {
+        return new BanAmmoFile(getBanAmmoPath());
     }
 
     /**
@@ -104,7 +115,7 @@ public abstract class AbstractFileSystem {
     public Path[] getConfigFiles() {
         Path[] configFiles = new Path[3];
 
-        configFiles[0] = getBanAmmo();
+        configFiles[0] = getBanAmmoPath();
         configFiles[1] = getOpList();
         configFiles[2] = getCampaignConfig();
         return configFiles;

--- a/MekWarsCommon/src/mekwars/common/io/file/BanAmmoFile.java
+++ b/MekWarsCommon/src/mekwars/common/io/file/BanAmmoFile.java
@@ -1,0 +1,118 @@
+/*
+ * MekWars - Copyright (C) 2026
+ *
+ * Derived from MegaMekNET (http://www.sourceforge.net/projects/megameknet) Original author Helge Richter (McWizard)
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ */
+
+package mekwars.common.io.file;
+
+import megamek.common.AmmoType;
+
+import mekwars.common.CampaignData;
+import mekwars.common.House;
+import mekwars.common.entities.BannedAmmo;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.FileNotFoundException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.StringTokenizer;
+
+public class BanAmmoFile {
+    private static final Logger LOGGER = LogManager.getLogger(BanAmmoFile.class);
+
+    private Path path;
+
+    public BanAmmoFile(Path path) {
+        this.path = path;
+    }
+
+    public Path getPath() {
+        return path;
+    }
+
+    public void load(CampaignData campaignData) {
+        try {
+            List<String> banAmmoLines = Files.readAllLines(getPath());
+
+            for (String line : banAmmoLines.subList(1, banAmmoLines.size())) {
+                loadLine(line, campaignData);
+            }
+        } catch (FileNotFoundException fne) {
+            LOGGER.info("No banned ammo data found.");
+        } catch (Exception ex) {
+            LOGGER.error("Unable to read " + path.getFileName(), ex);
+        }
+    }
+
+    public void loadLine(String line, CampaignData campaignData) {
+        try {
+            StringTokenizer st = new StringTokenizer(line, "#");
+            String houseName = (String) st.nextElement();
+            House faction = null;
+
+            if (!"server".equalsIgnoreCase(houseName)) {
+                faction = campaignData.getHouseByName(houseName);
+            }
+            while (st.hasMoreElements()) {
+                int munitionValue = Integer.parseInt(st.nextToken());
+                AmmoType.Munitions munition = BannedAmmo.getMunitionByNumber(munitionValue);
+
+                if (munition != null) {
+                    campaignData.getBannedAmmoStore().add(munition, faction);
+                }
+            }
+        } catch (Exception ex) {
+            LOGGER.error("Error loading banned ammo.", ex);
+        }
+    }
+
+    public void save(long timestamp, CampaignData campaignData) {
+        try {
+            // output streams
+            OutputStream out = Files.newOutputStream(getPath());
+            PrintStream p = new PrintStream(out);
+
+            // timestamp
+            p.println(timestamp);
+
+            Map<Optional<House>, List<BannedAmmo>> bannedAmmoByHouse =
+                campaignData.getBannedAmmoStore().groupByHouse();
+
+            for (Map.Entry<Optional<House>, List<BannedAmmo>> entry : bannedAmmoByHouse.entrySet()) {
+                Optional<House> house = entry.getKey();
+
+                if (house.isEmpty()) {
+                    p.print("server#");
+                } else {
+                    p.print(house.get().getName() + "#");
+                }
+
+                for (BannedAmmo bannedAmmo : entry.getValue()) {
+                    p.print(bannedAmmo.getId());
+                    p.print("#");
+                }
+                p.println();
+            }
+
+            // close streams
+            p.close();
+            out.close();
+        } catch (Exception ex) {
+            LOGGER.error("Error saving banned ammo.", ex);
+        }
+    }
+}

--- a/MekWarsCommon/src/mekwars/common/persistence/BannedAmmoStore.java
+++ b/MekWarsCommon/src/mekwars/common/persistence/BannedAmmoStore.java
@@ -1,0 +1,135 @@
+/*
+ * MekWars - Copyright (C) 2026
+ *
+ * Derived from MegaMekNET (http://www.sourceforge.net/projects/megameknet)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+package mekwars.common.persistence;
+
+import megamek.common.AmmoType;
+
+import mekwars.common.House;
+import mekwars.common.entities.BannedAmmo;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class BannedAmmoStore {
+    private ArrayList<BannedAmmo> bannedAmmoList = new ArrayList<>();
+
+    /**
+     * Adds the provided munition to the house's banned list.
+     *
+     * <p>If House is null the munition will be banned system wide.
+     *
+     * @return The added {@link BannedAmmo}
+     */
+    public BannedAmmo add(AmmoType.Munitions munition, House house) {
+        BannedAmmo bannedAmmo = get(munition, house);
+        if (bannedAmmo != null) {
+            return bannedAmmo;
+        }
+        bannedAmmo = new BannedAmmo(munition, house);
+        bannedAmmoList.add(bannedAmmo);
+        return bannedAmmo;
+    }
+
+    /** Removes the provided munition from the house's banned ammo list. */
+    public void remove(AmmoType.Munitions munition, House house) {
+        int index = 0;
+
+        for (BannedAmmo bannedAmmo : bannedAmmoList) {
+            if (bannedAmmo.getMunition() == munition
+                    && (house == null || house.equals(bannedAmmo.getHouse()))) {
+                bannedAmmoList.remove(index);
+                return;
+            }
+            ++index;
+        }
+    }
+
+    /**
+     * Returns the BannedAmmo that corresponds to the provided munition, otherwise null.
+     *
+     * @return The {@link BannedAmmo} that corresponds to the provided munition, otherwise null.
+     */
+    public BannedAmmo get(AmmoType.Munitions munition, House house) {
+        for (BannedAmmo bannedAmmo : bannedAmmoList) {
+            if (bannedAmmo.getMunition() == munition
+                    && (house == null || house.equals(bannedAmmo.getHouse()))) {
+                return bannedAmmo;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns true if {@code munition} is banned by {@code house}.
+     *
+     * @return true if {@code munition} is banned by {@code house}.
+     */
+    public boolean isBanned(AmmoType.Munitions munition, House house) {
+        for (BannedAmmo bannedAmmo : bannedAmmoList) {
+            if (bannedAmmo.getMunition() == munition
+                    && (house == null || house.equals(bannedAmmo.getHouse()))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns true if any munition in {@code munitions} is banned by {@code house}.
+     *
+     * @return true if any munition in {@code munitions} is banned by {@code house}.
+     */
+    public boolean isBanned(EnumSet<AmmoType.Munitions> munitions, House house) {
+        for (AmmoType.Munitions munition : munitions) {
+            if (isBanned(munition, house)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public Map<Optional<House>, List<BannedAmmo>> groupByHouse() {
+        return bannedAmmoList.stream()
+                .collect(
+                        Collectors.groupingBy(
+                                bannedAmmo -> Optional.ofNullable(bannedAmmo.getHouse())));
+    }
+
+    /**
+     * Get every {@link BannedAmmo} for the given house.
+     *
+     * @return Every {@link BannedAmmo} for the given house.
+     */
+    public List<BannedAmmo> getByHouse(House house) {
+        return bannedAmmoList.stream()
+                .filter(
+                        bannedAmmo ->
+                                (house != null)
+                                        ? house.equals(bannedAmmo.getHouse())
+                                        : bannedAmmo.getHouse() == null)
+                .collect(Collectors.toList());
+    }
+
+    /** Remove all banned ammos. */
+    public void clear() {
+        bannedAmmoList.clear();
+    }
+}

--- a/MekWarsServer/src/mekwars/server/campaign/CampaignMain.java
+++ b/MekWarsServer/src/mekwars/server/campaign/CampaignMain.java
@@ -12,19 +12,6 @@
 package mekwars.server.campaign;
 
 import com.thoughtworks.xstream.XStream;
-import mekwars.common.AdvancedTerrain;
-import mekwars.common.CampaignData;
-import mekwars.common.Continent;
-import mekwars.common.Equipment;
-import mekwars.common.House;
-import mekwars.common.Influences;
-import mekwars.common.Planet;
-import mekwars.common.Terrain;
-import mekwars.common.campaign.operations.Operation;
-import mekwars.common.flags.PlayerFlags;
-import mekwars.common.util.MekwarsFileReader;
-import mekwars.common.util.UnitUtils;
-import mekwars.server.common.util.SMMNetXStream;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -39,7 +26,6 @@ import java.io.Serializable;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.NumberFormat;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Enumeration;
@@ -52,7 +38,6 @@ import java.util.StringTokenizer;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.Vector;
-import megamek.MegaMek;
 import megamek.client.Client;
 import megamek.common.CriticalSlot;
 import megamek.common.Entity;
@@ -60,6 +45,18 @@ import megamek.common.Mech;
 import megamek.common.Mounted;
 import megamek.common.WeaponType;
 import megamek.common.options.IOption;
+import mekwars.common.AdvancedTerrain;
+import mekwars.common.CampaignData;
+import mekwars.common.Equipment;
+import mekwars.common.House;
+import mekwars.common.Influences;
+import mekwars.common.Planet;
+import mekwars.common.Terrain;
+import mekwars.common.campaign.operations.Operation;
+import mekwars.common.flags.PlayerFlags;
+import mekwars.common.io.file.BanAmmoFile;
+import mekwars.common.util.MekwarsFileReader;
+import mekwars.common.util.UnitUtils;
 import mekwars.server.MWServ;
 import mekwars.server.campaign.commands.*;
 import mekwars.server.campaign.commands.admin.*;
@@ -132,7 +129,6 @@ import mekwars.server.campaign.commands.mod.UpdateServerUnitsCacheCommand;
 import mekwars.server.campaign.commands.mod.ViewPlayerPartsCommand;
 import mekwars.server.campaign.commands.mod.ViewPlayerPersonalPilotQueueCommand;
 import mekwars.server.campaign.commands.mod.ViewPlayerUnitCommand;
-import mekwars.server.campaign.CampaignOptions;
 import mekwars.server.campaign.market2.Market2;
 import mekwars.server.campaign.market2.PartsMarket;
 import mekwars.server.campaign.mercenaries.ContractInfo;
@@ -151,10 +147,10 @@ import mekwars.server.campaign.util.WhoToHTML;
 import mekwars.server.campaign.util.scheduler.MWScheduler;
 import mekwars.server.campaign.util.scheduler.TickJob;
 import mekwars.server.campaign.votes.VoteManager;
+import mekwars.server.common.util.SMMNetXStream;
 import mekwars.server.io.FileSystem;
-import mekwars.server.util.MWPasswd;
 import mekwars.server.util.HtmlSanitizer;
-import mekwars.server.util.discord.DiscordMessageHandler;
+import mekwars.server.util.MWPasswd;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -255,15 +251,7 @@ public final class CampaignMain implements Serializable {
         loadFactionData();
         loadPlanetData();
 
-        try {
-            for (String line : Files.readAllLines(FileSystem.getInstance().getBanAmmo())) {
-                loadBanAmmo(line);
-            }
-        } catch (FileNotFoundException fne) {
-            LOGGER.info("No banned ammo data found.");
-        } catch (Exception ex) {
-            LOGGER.error("Problems reading banned ammo data.");
-        }
+        FileSystem.getInstance().getBanAmmoFile().load(data);
 
         // misc loads.
         cm.loadOmniVariantMods();
@@ -2281,10 +2269,6 @@ public final class CampaignMain implements Serializable {
         return Commands;
     }
 
-    public HashMap<String, String> getServerBannedAmmo() {
-        return cm.getData().getServerBannedAmmo();
-    }
-
     public double getAmmoCost(String ammo) {
         if (blackMarketEquipmentCostTable.containsKey(ammo) && blackMarketEquipmentCostTable.get(ammo).getMinCost() > 0) {
             return blackMarketEquipmentCostTable.get(ammo).getMinCost();
@@ -2481,27 +2465,6 @@ public final class CampaignMain implements Serializable {
         }
     }
 
-    public void loadBanAmmo(String line) {
-
-        try {
-            StringTokenizer st = new StringTokenizer(line, "#");
-            String HouseName = (String) st.nextElement();
-            SHouse faction = null;
-            if (!HouseName.equalsIgnoreCase("server")) {
-                faction = CampaignMain.cm.getHouseFromPartialString(HouseName, null);
-                while (st.hasMoreTokens()) {
-                    faction.getBannedAmmo().put(st.nextToken(), "Banned");
-                }
-            } else {
-                while (st.hasMoreElements()) {
-                    CampaignMain.cm.getServerBannedAmmo().put(st.nextToken(), "Banned");
-                }
-            }
-        } catch (Exception ex) {
-        }// make it compatible with people that had the old format,without
-        // the timestamp on the first line, the first time and now dont.
-    }
-
     public void loadBannedTargetSystems() {
         File tsFile = new File("./campaign/bantarget.dat");
         if(!tsFile.exists()) {
@@ -2519,7 +2482,7 @@ public final class CampaignMain implements Serializable {
             getData().setBannedTargetingSystems(bans);
             dis.close();
         } catch (IOException e) {
-                        e.printStackTrace();
+            LOGGER.error("Exception: ", e);
         }
     }
 
@@ -3338,47 +3301,6 @@ public final class CampaignMain implements Serializable {
         }
 
         return (int) cost;
-    }
-
-    public void saveBannedAmmo() {
-
-        // Save banned ammo
-        try {
-            FileOutputStream out = new FileOutputStream("./campaign/banammo.dat");
-            PrintStream p = new PrintStream(out);
-
-            // server banned ammo
-            p.println(System.currentTimeMillis());
-            p.print("server#");
-            for (String ammo : CampaignMain.cm.getServerBannedAmmo().keySet()) {
-                p.print(ammo);
-                p.print("#");
-            }
-            p.println();
-
-            // faction banned ammo
-            for (House currH : data.getAllHouses()) {
-
-                SHouse h = (SHouse) currH;
-                if (h.getBannedAmmo().size() < 1) {
-                    continue;
-                }
-
-                p.print(h.getName() + "#");
-                for (String ammo : h.getBannedAmmo().keySet()) {
-                    p.print(ammo);
-                    p.print("#");
-                }
-                p.println();
-
-            }
-            p.close();
-            out.close();
-
-        } catch (Exception ex) {
-            LOGGER.error("Error saving banned ammo.");
-            LOGGER.error("Exception: ", ex);
-        }
     }
 
     public void saveBannedTargetSystems() {

--- a/MekWarsServer/src/mekwars/server/campaign/SUnit.java
+++ b/MekWarsServer/src/mekwars/server/campaign/SUnit.java
@@ -167,7 +167,6 @@ public final class SUnit extends Unit implements Comparable<SUnit> {
      *            - SHouse unit is joining
      */
     public static void checkAmmoForUnit(SUnit u, SHouse h) {
-
         Entity en = u.getEntity();
         int year = CampaignMain.cm.getIntegerConfig("CampaignYear");
 
@@ -175,7 +174,6 @@ public final class SUnit extends Unit implements Comparable<SUnit> {
 
         for (Mounted mAmmo : en.getAmmo()) {
             AmmoType ammoType = (AmmoType) mAmmo.getType();
-            EnumSet<Munitions> munition = ammoType.getMunitionType();
 
             if (ammoType.getAmmoType() == AmmoType.T_ATM) {
                 continue;
@@ -198,28 +196,28 @@ public final class SUnit extends Unit implements Comparable<SUnit> {
                 continue;
             }
 
-            if (CampaignMain.cm.getData().getServerBannedAmmo().containsKey(munition) || h.getBannedAmmo().containsKey(munition)) {
+            for (Munitions munition : ammoType.getMunitionType()) {
+                if (CampaignMain.cm.getData().getBannedAmmoStore().isBanned(munition, h)) {
+                    Vector<AmmoType> types = AmmoType.getMunitionsFor(ammoType.getAmmoType());
+                    Enumeration<AmmoType> allTypes = types.elements();
 
-                Vector<AmmoType> types = AmmoType.getMunitionsFor(ammoType.getAmmoType());
-                Enumeration<AmmoType> allTypes = types.elements();
+                    boolean defaultFound = false;
+                    while (allTypes.hasMoreElements() && !defaultFound) {
+                        AmmoType currType = allTypes.nextElement();
 
-                boolean defaultFound = false;
-                while (allTypes.hasMoreElements() && !defaultFound) {
-                    AmmoType currType = allTypes.nextElement();
-
-                    if ((currType.getTechLevel(year) <= en.getTechLevel()) && (currType.getMunitionType().contains(AmmoType.Munitions.M_STANDARD)) && (currType.getRackSize() == ammoType.getRackSize())) {
-                        mAmmo.changeAmmoType(currType);
-                        if (mAmmo.byShot()) {
-                            mAmmo.setShotsLeft(mAmmo.getOriginalShots());
-                        } else {
-                            mAmmo.setShotsLeft(ammoType.getShots());
+                        if ((currType.getTechLevel(year) <= en.getTechLevel()) && (currType.getMunitionType().contains(AmmoType.Munitions.M_STANDARD)) && (currType.getRackSize() == ammoType.getRackSize())) {
+                            mAmmo.changeAmmoType(currType);
+                            if (mAmmo.byShot()) {
+                                mAmmo.setShotsLeft(mAmmo.getOriginalShots());
+                            } else {
+                                mAmmo.setShotsLeft(ammoType.getShots());
+                            }
+                            defaultFound = true;
+                            wasChanged = true;
                         }
-                        defaultFound = true;
-                        wasChanged = true;
                     }
-                } // end while
-            } // end if(is banned)
-
+                }
+            }
         }
         if (wasChanged) {
             u.setEntity(en);
@@ -645,10 +643,8 @@ public final class SUnit extends Unit implements Comparable<SUnit> {
                         // loaded --Torren.
                         continue;
                     }
-                    EnumSet<Munitions> munition = ammoType.getMunitionType();
 
-                    // check banned ammo
-                    if (CampaignMain.cm.getData().getServerBannedAmmo().get(munition) != null) {
+                    if (CampaignMain.cm.getData().getBannedAmmoStore().isBanned(ammoType.getMunitionType(), null)) {
                         continue;
                     }
 

--- a/MekWarsServer/src/mekwars/server/campaign/commands/SetUnitAmmoByCritCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/SetUnitAmmoByCritCommand.java
@@ -112,13 +112,11 @@ public class SetUnitAmmoByCritCommand implements Command {
             CampaignMain.cm.toUser("AM:Ammo dumped. BV Recalculated", Username, true);
             return;
         }
-
-        EnumSet<Munitions> munitionType = ammoType.getMunitionType();
         // dont make players confirm the command on a server which doesnt charge
         // for ammo
         double ammoCharge = CampaignMain.cm.getAmmoCost(currAmmo.getInternalName());
 
-        if ((CampaignMain.cm.getData().getServerBannedAmmo().get(munitionType) != null) || (faction.getBannedAmmo().get(munitionType) != null) || ((ammoCharge < 0) && !usingCrits)) {
+        if (CampaignMain.cm.getData().getBannedAmmoStore().isBanned(ammoType.getMunitionType(), faction) || ((ammoCharge < 0) && !usingCrits)) {
             CampaignMain.cm.toUser("AM:<font color=green>Quartermaster Command regretfully informs you that " + ammoType.getName() + " is out of stock.</font>", Username, true);
             return;
         }

--- a/MekWarsServer/src/mekwars/server/campaign/commands/SetUnitAmmoCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/SetUnitAmmoCommand.java
@@ -149,7 +149,7 @@ public class SetUnitAmmoCommand implements Command {
         // for ammo
         double ammoCharge = CampaignMain.cm.getAmmoCost(at.getInternalName());
 
-        if ((CampaignMain.cm.getData().getServerBannedAmmo().get(munitionType) != null) || (faction.getBannedAmmo().get(munitionType) != null) || ((ammoCharge < 0) && !usingCrits)) {
+        if (CampaignMain.cm.getData().getBannedAmmoStore().isBanned(at.getMunitionType(), faction) || ((ammoCharge < 0) && !usingCrits)) {
             CampaignMain.cm.toUser("AM:<font color=green>Quartermaster Command regretfully informs you that " + at.getName() + " is out of stock.</font>", Username, true);
             return;
         }

--- a/MekWarsServer/src/mekwars/server/campaign/commands/admin/AdminListHouseBannedAmmoCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/admin/AdminListHouseBannedAmmoCommand.java
@@ -17,12 +17,10 @@
 package mekwars.server.campaign.commands.admin;
 
 
-import java.util.Enumeration;
-import java.util.HashMap;
+import java.util.List;
 import java.util.StringTokenizer;
 
-import megamek.common.AmmoType;
-import megamek.common.AmmoType.Munitions;
+import mekwars.common.entities.BannedAmmo;
 import mekwars.server.MWServ;
 import mekwars.server.MWChatServer.auth.IAuthenticator;
 import mekwars.server.campaign.CampaignMain;
@@ -46,7 +44,6 @@ public class AdminListHouseBannedAmmoCommand implements Command {
     }
 
     public void process(StringTokenizer command, String username) {
-
         //access level check
         int userLevel = MWServ.getInstance().getUserLevel(username);
         if (userLevel < getExecutionLevel()) {
@@ -62,22 +59,14 @@ public class AdminListHouseBannedAmmoCommand implements Command {
             return;
         }
 
-        SHouse h = CampaignMain.cm.getHouseFromPartialString(faction, username);
+        SHouse house = CampaignMain.cm.getHouseFromPartialString(faction, username);
 
-        if (h == null || h.getBannedAmmo().size() <= 0) {
-            CampaignMain.cm.toUser("That faction is not currently banning any ammo.", username, true);
+        List<BannedAmmo> houseBannedAmmo = CampaignMain.cm.getData().getBannedAmmoStore().getByHouse(house);
+
+        if (houseBannedAmmo.isEmpty()) {
+            CampaignMain.cm.toUser(faction + " is not currently banning any ammo.", username, true);
         } else {
-            CampaignMain.cm.toUser("Banned ammo for Faction " + h.getName(), username, true);
-            Enumeration<String> ammoBan = h.getBannedAmmo().keys();
-            HashMap<Munitions, String> munitions = CampaignMain.cm.getData().getMunitionsByNumber();
-            Munitions[] munitionValues = Munitions.values();
-            
-            while (ammoBan.hasMoreElements()) {
-                String ammoName = ammoBan.nextElement();
-                int ammoType = Integer.parseInt(ammoName);
-
-                CampaignMain.cm.toUser(munitions.get(munitionValues[ammoType]), username, true);
-            }
+            houseBannedAmmo.forEach(each -> CampaignMain.cm.toUser(each.getName(), username, true));
         }
     } //end process
 }

--- a/MekWarsServer/src/mekwars/server/campaign/commands/admin/AdminListServerBannedAmmoCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/admin/AdminListServerBannedAmmoCommand.java
@@ -16,12 +16,12 @@
 
 package mekwars.server.campaign.commands.admin;
 
-import java.util.HashMap;
+import java.util.List;
 import java.util.StringTokenizer;
-import java.util.TreeSet;
-import megamek.common.AmmoType.Munitions;
-import mekwars.server.MWChatServer.auth.IAuthenticator;
+
+import mekwars.common.entities.BannedAmmo;
 import mekwars.server.MWServ;
+import mekwars.server.MWChatServer.auth.IAuthenticator;
 import mekwars.server.campaign.CampaignMain;
 import mekwars.server.campaign.commands.Command;
 
@@ -49,16 +49,14 @@ public class AdminListServerBannedAmmoCommand implements Command {
             return;
         }
 
-        if (CampaignMain.cm.getServerBannedAmmo().size() <= 0) {
+        List<BannedAmmo> serverBannedAmmo = CampaignMain.cm.getData().getBannedAmmoStore().getByHouse(null);
+
+        if (serverBannedAmmo.isEmpty()) {
             CampaignMain.cm.toUser("The server is not currently banning any ammo.", username, true);
         } else {
-            TreeSet<String> ammoBan = new TreeSet<String>(CampaignMain.cm.getServerBannedAmmo().keySet());
-            HashMap<Munitions, String> munitions = CampaignMain.cm.getData().getMunitionsByNumber();
-            Munitions[] munitionValues = Munitions.values();
-            
-            for (String ammoName : ammoBan) {
-                CampaignMain.cm.toUser(munitions.get(munitionValues[Integer.parseInt(ammoName)]), username, true);
-            }
+            for (BannedAmmo bannedAmmo : serverBannedAmmo) {
+                CampaignMain.cm.toUser(bannedAmmo.getName(), username, true);
+            } 
         }
     } //end process
 }

--- a/MekWarsServer/src/mekwars/server/campaign/commands/admin/AdminSaveCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/admin/AdminSaveCommand.java
@@ -1,6 +1,6 @@
 /*
- * MekWars - Copyright (C) 2004 
- * 
+ * MekWars - Copyright (C) 2004
+ *
  * Derived from MegaMekNET (http://www.sourceforge.net/projects/megameknet)
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -17,34 +17,45 @@
 package mekwars.server.campaign.commands.admin;
 
 import java.util.StringTokenizer;
-import mekwars.server.MWServ;
 import mekwars.server.MWChatServer.auth.IAuthenticator;
+import mekwars.server.MWServ;
 import mekwars.server.campaign.CampaignMain;
 import mekwars.server.campaign.commands.Command;
-
+import mekwars.server.io.FileSystem;
 
 public class AdminSaveCommand implements Command {
-	
-	int accessLevel = IAuthenticator.ADMIN;
-	String syntax = "";
-	public int getExecutionLevel(){return accessLevel;}
-	public void setExecutionLevel(int i) {accessLevel = i;}
-	public String getSyntax() { return syntax;}
-	
-	public void process(StringTokenizer command,String Username) {
-		
-		//access level check
-		int userLevel = MWServ.getInstance().getUserLevel(Username);
-		if(userLevel < getExecutionLevel()) {
-			CampaignMain.cm.toUser("AM:Insufficient access level for command. Level: " + userLevel + ". Required: " + accessLevel + ".",Username,true);
-			return;
-		}
-		
-		CampaignMain.cm.toFile();
-		CampaignMain.cm.forceSavePlayers(Username);
-        CampaignMain.cm.saveBannedAmmo();
-		CampaignMain.cm.toUser("AM:Status saved!",Username,true);
-		CampaignMain.cm.doSendModMail("NOTE",Username + " has saved the status files");
-		
-	}
+
+    int accessLevel = IAuthenticator.ADMIN;
+    String syntax = "";
+
+    public int getExecutionLevel() {
+        return accessLevel;
+    }
+
+    public void setExecutionLevel(int i) {
+        accessLevel = i;
+    }
+
+    public String getSyntax() {
+        return syntax;
+    }
+
+    public void process(StringTokenizer command, String username) {
+        //access level check
+        int userLevel = MWServ.getInstance().getUserLevel(username);
+        if (userLevel < getExecutionLevel()) {
+            CampaignMain.cm.toUser("AM:Insufficient access level for command. Level: " + userLevel + ". Required: " + accessLevel + ".", username, true);
+            return;
+        }
+
+        CampaignMain.cm.toFile();
+        CampaignMain.cm.forceSavePlayers(username);
+        FileSystem.getInstance().getBanAmmoFile().save(
+            System.currentTimeMillis(),
+            CampaignMain.cm.getData()
+        );
+        CampaignMain.cm.toUser("AM:Status saved!", username, true);
+        CampaignMain.cm.doSendModMail("NOTE", username + " has saved the status files");
+
+    }
 }

--- a/MekWarsServer/src/mekwars/server/campaign/commands/admin/AdminSetHouseAmmoBanCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/admin/AdminSetHouseAmmoBanCommand.java
@@ -1,6 +1,6 @@
 /*
- * MekWars - Copyright (C) 2004 
- * 
+ * MekWars - Copyright (C) 2004
+ *
  * Derived from MegaMekNET (http://www.sourceforge.net/projects/megameknet)
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -16,62 +16,96 @@
 
 package mekwars.server.campaign.commands.admin;
 
-import java.util.StringTokenizer;
 import megamek.common.AmmoType;
-import mekwars.server.MWServ;
+
+import mekwars.common.entities.BannedAmmo;
 import mekwars.server.MWChatServer.auth.IAuthenticator;
+import mekwars.server.MWServ;
 import mekwars.server.campaign.CampaignMain;
 import mekwars.server.campaign.SHouse;
 import mekwars.server.campaign.commands.Command;
+import mekwars.server.io.FileSystem;
+
+import java.util.StringTokenizer;
 
 public class AdminSetHouseAmmoBanCommand implements Command {
-	
-	int accessLevel = IAuthenticator.ADMIN;
-	String syntax = "Faction Name#Munition Number";
-	public int getExecutionLevel(){return accessLevel;}
-	public void setExecutionLevel(int i) {accessLevel = i;}
-	public String getSyntax() { return syntax;}
-	
-	public void process(StringTokenizer command,String Username) {
-		
-		//access level check
-		int userLevel = MWServ.getInstance().getUserLevel(Username);
-		if(userLevel < getExecutionLevel()) {
-			CampaignMain.cm.toUser("AM:Insufficient access level for command. Level: " + userLevel + ". Required: " + accessLevel + ".",Username,true);
-			return;
-		}
-		
-		String faction = "";
-		String ammoName = "";
-		try{
-		    faction = command.nextToken();
-			ammoName = command.nextToken();
-		}
-		catch (Exception ex){
-			CampaignMain.cm.toUser("Invalid syntax. Try: adminsethouseammoban#faction#munitionnumber",Username,true);
-		}
-		
-		SHouse h = CampaignMain.cm.getHouseFromPartialString(faction,Username);
-		
-		if ( h == null )
-		    return;
-		 
-		//Hashtable munitions = CampaignMain.cm.getData().getMunitionsByNumber();
-		
-		if ( h.getBannedAmmo().get(ammoName)!= null ){
-		    h.getBannedAmmo().remove(ammoName);
-			ammoName = CampaignMain.cm.getData().getMunitionsByNumber().get(AmmoType.Munitions.values()[Integer.parseInt(ammoName)]);
-			CampaignMain.cm.toUser("Ban on " + ammoName + " lifted for "+h.getName() + ".",Username,true);
-			CampaignMain.cm.doSendModMail("NOTE",Username + " lifted the ban on " + ammoName+ " for " + h.getName() + ".");
-		}
-		else {
-		    h.getBannedAmmo().put(ammoName,"banned");
-			ammoName = CampaignMain.cm.getData().getMunitionsByNumber().get(AmmoType.Munitions.values()[Integer.parseInt(ammoName)]);
-			CampaignMain.cm.toUser("Banned " + ammoName + " for "+h.getName() + ".",Username,true);
-			CampaignMain.cm.doSendModMail("NOTE",Username + " banned " + ammoName+ " for " + h.getName() + ".");
-		}
-	
-		h.updated();
-        CampaignMain.cm.saveBannedAmmo();
-	}
+    int accessLevel = IAuthenticator.ADMIN;
+    String syntax = "Faction Name#Munition Number";
+
+    public int getExecutionLevel() {
+        return accessLevel;
+    }
+
+    public void setExecutionLevel(int i) {
+        accessLevel = i;
+    }
+
+    public String getSyntax() {
+        return syntax;
+    }
+
+    public void process(StringTokenizer command, String username) {
+        // access level check
+        int userLevel = MWServ.getInstance().getUserLevel(username);
+        if (userLevel < getExecutionLevel()) {
+            CampaignMain.cm.toUser(
+                    "AM:Insufficient access level for command. Level: "
+                            + userLevel
+                            + ". Required: "
+                            + accessLevel
+                            + ".",
+                    username,
+                    true);
+            return;
+        }
+
+        String faction = "";
+        String ammoName = "";
+        try {
+            faction = command.nextToken();
+            ammoName = command.nextToken();
+        } catch (Exception ex) {
+            CampaignMain.cm.toUser(
+                    "Invalid syntax. Try: adminsethouseammoban#faction#munitionnumber",
+                    username,
+                    true);
+        }
+
+        SHouse h = CampaignMain.cm.getHouseFromPartialString(faction, username);
+        if (h != null) {
+            AmmoType.Munitions munition =
+                    BannedAmmo.getMunitionByNumber(Integer.parseInt(ammoName));
+            BannedAmmo bannedAmmo = CampaignMain.cm.getData().getBannedAmmoStore().get(munition, h);
+
+            if (bannedAmmo != null) {
+                CampaignMain.cm.getData().getBannedAmmoStore().remove(munition, h);
+                CampaignMain.cm.toUser(
+                        "Ban on " + bannedAmmo.getName() + " lifted for " + h.getName() + ".",
+                        username,
+                        true);
+                CampaignMain.cm.doSendModMail(
+                        "NOTE",
+                        username
+                                + " lifted the ban on "
+                                + bannedAmmo.getName()
+                                + " for "
+                                + h.getName()
+                                + ".");
+            } else {
+                bannedAmmo = CampaignMain.cm.getData().getBannedAmmoStore().add(munition, h);
+                CampaignMain.cm.toUser(
+                        "Banned " + bannedAmmo.getName() + " for " + h.getName() + ".",
+                        username,
+                        true);
+                CampaignMain.cm.doSendModMail(
+                        "NOTE",
+                        username + " banned " + bannedAmmo.getName() + " for " + h.getName() + ".");
+            }
+
+            h.updated();
+            FileSystem.getInstance()
+                    .getBanAmmoFile()
+                    .save(System.currentTimeMillis(), CampaignMain.cm.getData());
+        }
+    }
 }

--- a/MekWarsServer/src/mekwars/server/campaign/commands/admin/AdminSetServerAmmoBanCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/admin/AdminSetServerAmmoBanCommand.java
@@ -17,11 +17,14 @@
 package mekwars.server.campaign.commands.admin;
 
 import java.util.StringTokenizer;
+
 import megamek.common.AmmoType;
-import mekwars.server.MWChatServer.auth.IAuthenticator;
+import mekwars.common.entities.BannedAmmo;
 import mekwars.server.MWServ;
+import mekwars.server.MWChatServer.auth.IAuthenticator;
 import mekwars.server.campaign.CampaignMain;
 import mekwars.server.campaign.commands.Command;
+import mekwars.server.io.FileSystem;
 
 public class AdminSetServerAmmoBanCommand implements Command {
     int accessLevel = IAuthenticator.ADMIN;
@@ -54,20 +57,21 @@ public class AdminSetServerAmmoBanCommand implements Command {
             CampaignMain.cm.toUser("Invalid syntax. Try: adminsetserveradmmoban#munitionnumber", username, true);
         }
 
-        if (CampaignMain.cm.getServerBannedAmmo().get(ammoName) != null) {
-            CampaignMain.cm.getServerBannedAmmo().remove(ammoName);
-            CampaignMain.cm.getData().setServerBannedAmmo(CampaignMain.cm.getServerBannedAmmo());
-            ammoName = CampaignMain.cm.getData().getMunitionsByNumber().get(AmmoType.Munitions.values()[Integer.parseInt(ammoName)]);
-            CampaignMain.cm.toUser("Server-wide ban on " + ammoName + " lifted.", username, true);
-            CampaignMain.cm.doSendModMail("NOTE", username + " lifted the server-wide ban on " + ammoName + ".");
-        } else {
-            CampaignMain.cm.getServerBannedAmmo().put(ammoName, "banned");
-            CampaignMain.cm.getData().setServerBannedAmmo(CampaignMain.cm.getServerBannedAmmo());
-            ammoName = CampaignMain.cm.getData().getMunitionsByNumber().get(AmmoType.Munitions.values()[Integer.parseInt(ammoName)]);
-            CampaignMain.cm.toUser(ammoName + " banned server-wide.", username, true);
-            CampaignMain.cm.doSendModMail("NOTE", username + " banned " + ammoName + " server-wide.");
-        }
+        AmmoType.Munitions munition = BannedAmmo.getMunitionByNumber(Integer.parseInt(ammoName));
+        BannedAmmo bannedAmmo = CampaignMain.cm.getData().getBannedAmmoStore().get(munition, null);
 
-        CampaignMain.cm.saveBannedAmmo();
+        if (bannedAmmo != null) {
+            CampaignMain.cm.getData().getBannedAmmoStore().remove(munition, null);
+            CampaignMain.cm.toUser("Server-wide ban on " + bannedAmmo.getName() + " lifted.", username, true);
+            CampaignMain.cm.doSendModMail("NOTE", username + " lifted the server-wide ban on " + bannedAmmo.getName() + ".");
+        } else {
+            bannedAmmo = CampaignMain.cm.getData().getBannedAmmoStore().add(munition, null);
+            CampaignMain.cm.toUser(bannedAmmo.getName() + " banned server-wide.", username, true);
+            CampaignMain.cm.doSendModMail("NOTE", username + " banned " + bannedAmmo.getName() + " server-wide.");
+        }
+        FileSystem.getInstance().getBanAmmoFile().save(
+            System.currentTimeMillis(),
+            CampaignMain.cm.getData()
+        );
     }
 }

--- a/MekWarsServer/src/mekwars/server/campaign/commands/admin/ShutdownCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/admin/ShutdownCommand.java
@@ -1,13 +1,13 @@
 /*
  * MekWars - Copyright (C) 2006
- * 
+ *
  * Original author - Jason Tighe (torren@users.sourceforge.net)
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
  * Foundation; either version 2 of the License, or (at your option) any later
  * version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
@@ -17,15 +17,15 @@
 package mekwars.server.campaign.commands.admin;
 
 import java.util.StringTokenizer;
-import mekwars.server.MWServ;
 import mekwars.server.MWChatServer.auth.IAuthenticator;
+import mekwars.server.MWServ;
 import mekwars.server.campaign.CampaignMain;
 import mekwars.server.campaign.commands.Command;
 import mekwars.server.campaign.util.scheduler.MWScheduler;
 import mekwars.server.util.MWPasswd;
+import mekwars.server.io.FileSystem;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
 
 /**
  * Moving the Shutdown command from MWServ into the normal command structure.
@@ -35,37 +35,46 @@ import org.apache.logging.log4j.Logger;
 public class ShutdownCommand implements Command {
     private static final Logger LOGGER = LogManager.getLogger(ShutdownCommand.class);
 
-	int accessLevel = IAuthenticator.ADMIN;
-	String syntax = "";
-	public int getExecutionLevel(){return accessLevel;}
-	public void setExecutionLevel(int i) {accessLevel = i;}
-	public String getSyntax() { return syntax;}
-	
-	public void process(StringTokenizer command,String Username) {
-		
-		if (accessLevel != 0) {
-			int userLevel = MWServ.getInstance().getUserLevel(Username);
-			if(userLevel < getExecutionLevel()) {
-				CampaignMain.cm.toUser("AM:Insufficient access level for command. Level: " + userLevel + ". Required: " + accessLevel + ".",Username,true);
-				return;
-			}
-		}
-		MWScheduler.getInstance().shutdown();
-		
+    int accessLevel = IAuthenticator.ADMIN;
+    String syntax = "";
+    public int getExecutionLevel() {
+        return accessLevel;
+    }
+    public void setExecutionLevel(int i) {
+        accessLevel = i;
+    }
+    public String getSyntax() {
+        return syntax;
+    }
+
+    public void process(StringTokenizer command, String Username) {
+
+        if (accessLevel != 0) {
+            int userLevel = MWServ.getInstance().getUserLevel(Username);
+            if (userLevel < getExecutionLevel()) {
+                CampaignMain.cm.toUser("AM:Insufficient access level for command. Level: " + userLevel + ". Required: " + accessLevel + ".", Username, true);
+                return;
+            }
+        }
+        MWScheduler.getInstance().shutdown();
+
         CampaignMain.cm.getMarket().removeAllListings();
-		CampaignMain.cm.toFile();
-		CampaignMain.cm.forceSavePlayers(Username);
-        CampaignMain.cm.saveBannedAmmo();
+        CampaignMain.cm.toFile();
+        CampaignMain.cm.forceSavePlayers(Username);
+        FileSystem.getInstance().getBanAmmoFile().save(
+            System.currentTimeMillis(),
+            CampaignMain.cm.getData()
+        );
         CampaignMain.cm.getDefaultPlayerFlags().save();
-        CampaignMain.cm.toUser("AM:You halted the server. Have a nice day.", Username,true);
+        CampaignMain.cm.toUser("AM:You halted the server. Have a nice day.", Username, true);
         LOGGER.info(Username + " halted the server. Have a nice day!");
         MWServ.getInstance().addToNewsFeed("Server halted!", "Server News", "");
         MWServ.getInstance().postToDiscord("Server halted!");
         try {
             MWPasswd.save();
-        } catch(Exception ex) {
+        } catch (Exception ex) {
         }
-        
+
         System.exit(0);
-	}
+    }
 }

--- a/MekWarsServer/src/mekwars/server/dataProvider/commands/BannedAmmo.java
+++ b/MekWarsServer/src/mekwars/server/dataProvider/commands/BannedAmmo.java
@@ -1,6 +1,6 @@
 /*
- * MekWars - Copyright (C) 2004 
- * 
+ * MekWars - Copyright (C) 2004
+ *
  * Derived from MegaMekNET (http://www.sourceforge.net/projects/megameknet)
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -16,6 +16,11 @@
 
 package mekwars.server.dataProvider.commands;
 
+import mekwars.common.CampaignData;
+import mekwars.common.util.BinWriter;
+import mekwars.server.dataProvider.ServerCommand;
+import mekwars.server.io.FileSystem;
+
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -24,43 +29,39 @@ import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.util.Date;
 
-import mekwars.common.CampaignData;
-import mekwars.common.util.BinWriter;
-import mekwars.server.dataProvider.ServerCommand;
-
 /**
  * Retrieve all planet information (if the data cache is lost at client side)
- * 
+ *
  * @author Imi (immanuel.scholz@gmx.de)
  */
 public class BannedAmmo implements ServerCommand {
 
     /**
-     * @see server.dataProvider.ServerCommand#execute(java.util.Date,
-     *      java.io.PrintWriter, common.CampaignData)
+     * @see server.dataProvider.ServerCommand#execute(java.util.Date, java.io.PrintWriter,
+     *     common.CampaignData)
      */
-    public void execute(Date timestamp, BinWriter out, CampaignData data)
-            throws Exception {
-    		FileInputStream configFile; 
-    	    try{
-    	    	configFile = new FileInputStream("./campaign/banammo.dat");
-    	    }catch (FileNotFoundException FNFE){
-    			FileOutputStream ban = new FileOutputStream("./campaign/banammo.dat");
-    			PrintStream p = new PrintStream(ban);
-    			
-    			//server banned ammo
-    			p.println(System.currentTimeMillis());
-    			p.println("server#");
-    			ban.close();
-    			p.close();
-    			configFile = new FileInputStream("./campaign/banammo.dat");
-    	    }
-            BufferedReader config = new BufferedReader(new InputStreamReader(configFile));
-            
-            while (config.ready()) {
-                out.println(config.readLine(),"BannedAmmo");
-            }
-            config.close();
-            configFile.close();
+    public void execute(Date timestamp, BinWriter out, CampaignData data) throws Exception {
+        FileInputStream configFile;
+        String banAmmoPath = FileSystem.getInstance().getBanAmmoPath().toFile().toString();
+        try {
+            configFile = new FileInputStream(banAmmoPath);
+        } catch (FileNotFoundException FNFE) {
+            FileOutputStream ban = new FileOutputStream(banAmmoPath);
+            PrintStream p = new PrintStream(ban);
+
+            // server banned ammo
+            p.println(System.currentTimeMillis());
+            p.println("server#");
+            ban.close();
+            p.close();
+            configFile = new FileInputStream(banAmmoPath);
         }
+        BufferedReader config = new BufferedReader(new InputStreamReader(configFile));
+
+        while (config.ready()) {
+            out.println(config.readLine(), "BannedAmmo");
+        }
+        config.close();
+        configFile.close();
+    }
 }

--- a/MekWarsServer/src/mekwars/server/io/FileSystem.java
+++ b/MekWarsServer/src/mekwars/server/io/FileSystem.java
@@ -17,7 +17,6 @@
 
 package mekwars.server.io;
 
-import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import mekwars.common.io.AbstractFileSystem;
@@ -157,7 +156,8 @@ public class FileSystem extends AbstractFileSystem {
         );
     }
 
-    public Path getBanAmmo() {
+    @Override
+    public Path getBanAmmoPath() {
         return FileSystems.getDefault().getPath(getCampaignDir().toString(), FILE_NAME_BAN_AMMO);
     }
 


### PR DESCRIPTION
This PR is a refactor for the ban ammo file, putting various banned ammo related code into the `BanAmmoFile` to reduplicate loading/saving, and the `BanAmmo` entity and store files making the code clearer.

Both faction and server wide banned ammo entries are now in the same list stored in `BanAmmoStore`, with `BanAmmo` being an `Entity`. Any class that is an `Entity` should eventually be stored into a SQL database.