### PR TITLE
Refactor SHouse configuration into HouseOptions

### DIFF
--- a/MekWarsClient/src/mekwars/client/campaign/CPlayer.java
+++ b/MekWarsClient/src/mekwars/client/campaign/CPlayer.java
@@ -17,6 +17,7 @@
 
 package mekwars.client.campaign;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -27,9 +28,10 @@ import java.util.Vector;
 import mekwars.client.MWClient;
 import mekwars.client.GUIClient;
 import mekwars.client.common.campaign.clientutils.GameHost;
-import mekwars.client.gui.CPlayerPanel;
+import mekwars.client.io.FileSystem;
 import mekwars.client.util.CArmyComparator;
 import mekwars.client.util.CUnitComparator;
+import mekwars.common.CampaignData;
 import mekwars.common.House;
 import mekwars.common.Player;
 import mekwars.common.SubFaction;
@@ -216,7 +218,7 @@ public class CPlayer extends Player {
         doPayTechniciansMath();
         RewardPoints = TokenReader.readInt(ST);
         String string = TokenReader.readString(ST);
-           setMekToken(Integer.parseInt(string));
+        setMekToken(Integer.parseInt(string));
         House = TokenReader.readString(ST);
         setHouseFightingFor(TokenReader.readString(ST));
         setLogo(TokenReader.readString(ST));
@@ -294,8 +296,8 @@ public class CPlayer extends Player {
             if (i.next().getID() == lanceID) {
                 i.remove();
                 mwclient.getGUIClient().getMainFrame().updateAttackMenu();// removing an army
-                // needs to reset
-                // menu
+                                                                          // needs to reset
+                                                                          // menu
                 return (true);
             }
         }
@@ -618,35 +620,35 @@ public class CPlayer extends Player {
         }
         return null;
     }
-    
+
     //@salient- compare client quirks with server
-    // lol while this works, realized the way i'm doing things makes this check meaningless... 
+    // lol while this works, realized the way i'm doing things makes this check meaningless...
     // what needs to be checked is the hosts xmls, not the client quirks
     // which are already set by the server anyway....
-//    public String getAllQuirkInfoForActivation()
-//    {
-//        StringJoiner quirksList = new StringJoiner("*");
-//        List<Integer> idList = new ArrayList<Integer>();
-//        
-//        for (CArmy currA : Armies) 
-//        {
-//            for (Unit currU : currA.getUnits())
-//            {
-//                CUnit currCU = (CUnit) currU;
-//                if(currCU.hasQuirks())
-//                {
-//                    int ID = currCU.getId();
-//                    if(idList.contains(ID)) //skip dupes
-//                        continue;
-//                    idList.add(ID);
-//                    quirksList.add(String.valueOf(ID));
-//                    quirksList.add(currCU.getQuirksList());                    
-//                }
-//            }
-//        }
-//        LOGGER.debug(quirksList.toString());
-//        return quirksList.toString();
-//    }
+    //    public String getAllQuirkInfoForActivation()
+    //    {
+    //        StringJoiner quirksList = new StringJoiner("*");
+    //        List<Integer> idList = new ArrayList<Integer>();
+    //
+    //        for (CArmy currA : Armies)
+    //        {
+    //            for (Unit currU : currA.getUnits())
+    //            {
+    //                CUnit currCU = (CUnit) currU;
+    //                if(currCU.hasQuirks())
+    //                {
+    //                    int ID = currCU.getId();
+    //                    if(idList.contains(ID)) //skip dupes
+    //                        continue;
+    //                    idList.add(ID);
+    //                    quirksList.add(String.valueOf(ID));
+    //                    quirksList.add(currCU.getQuirksList());
+    //                }
+    //            }
+    //        }
+    //        LOGGER.debug(quirksList.toString());
+    //        return quirksList.toString();
+    //    }
 
     public int getAmountOfTimesUnitExistsInArmies(int unitID) {
         int result = 0;
@@ -1040,7 +1042,7 @@ public class CPlayer extends Player {
         // Choices [note - this array must be duplicated in CHQPanel's
         // maybeShowPopup()]
         String[] choices =
-            { "Name", "Battle Value", "Gunnery Skill", "ID Number", "MP (Jumping)", "MP (Walking)", "Pilot Kills", "Unit Type", "Weight (Class)", "Weight (Tons)", "No Sort" };
+        { "Name", "Battle Value", "Gunnery Skill", "ID Number", "MP (Jumping)", "MP (Walking)", "Pilot Kills", "Unit Type", "Weight (Class)", "Weight (Tons)", "No Sort" };
 
         // determine which sort will dominate
         int primarySort = CUnitComparator.HQSORT_NONE;
@@ -1124,7 +1126,7 @@ public class CPlayer extends Player {
         // Choices [note - this array must be duplicated in CHQPanel's
         // maybeShowPopup()]
         String[] choices =
-            { "Name", "Battle Value", "ID Number", "Max Tonnage", "Avg Walk MP", "Avg Jump MP", "Number Of Units", "No Sort" };
+        { "Name", "Battle Value", "ID Number", "Max Tonnage", "Avg Walk MP", "Avg Jump MP", "Number Of Units", "No Sort" };
 
         // determine which sort will dominate
         int primarySort = CArmyComparator.ARMYSORT_NONE;
@@ -1312,15 +1314,24 @@ public class CPlayer extends Player {
     }
 
     public void setFactionConfigs(String data) {
+        /**
+         * FIXME: This is a hack. Currently the house config files only exist on the server and are
+         * then appended to the campaignconfig.txt above. In order to make the server and client
+         * both use the House's config file we create a dummy config below that will have no
+         * parameters and pass through to the campaignconfig.txt. Later this hack will be removed
+         * when house config files exist properly on the client side.
+         */
+        if (CampaignData.cd.getHouseOptions(getMyHouse().getName()) == null) {
+            Path configPath = FileSystem.getInstance().getFactionConfigPath(getMyHouse().getName());
 
+            CampaignData.cd.loadHouseOptions(configPath, getMyHouse());
+        }
         if (data.startsWith("DONE#DONE")) {
             mwclient.setWaiting(false);
             return;
         }
 
         StringTokenizer ST = new StringTokenizer(data, DELIMITER);
-        // mwclient.getServerConfigs().clear();
-        // mwclient.getServerConfigData();
         while (ST.hasMoreTokens()) {
             String key = TokenReader.readString(ST);
             String value = TokenReader.readString(ST);

--- a/MekWarsClient/src/mekwars/client/protocol/DataFetchClient.java
+++ b/MekWarsClient/src/mekwars/client/protocol/DataFetchClient.java
@@ -529,7 +529,7 @@ public class DataFetchClient {
     public CampaignData getAllData() throws IOException {
         BinReader in = openConnection("All");
         CampaignOptions campaignOptions =
-            new CampaignOptions(FileSystem.getInstance().getCampaignConfig().toString());
+            new CampaignOptions(FileSystem.getInstance().getCampaignConfig());
         CampaignData data = new CampaignData(campaignOptions, in);
         // in.close();
         getAccessLevels(data);
@@ -546,7 +546,7 @@ public class DataFetchClient {
     public CampaignData getCacheData(String cachePath) throws IOException {
         BinReader in = new BinReader(new FileReader(cachePath + "/data.dat"));
         CampaignOptions campaignOptions =
-            new CampaignOptions(FileSystem.getInstance().getCampaignConfig().toString());
+            new CampaignOptions(FileSystem.getInstance().getCampaignConfig());
         CampaignData data = new CampaignData(campaignOptions, in);
         in.close();
         this.data = data;

--- a/MekWarsCommon/src/mekwars/common/CampaignData.java
+++ b/MekWarsCommon/src/mekwars/common/CampaignData.java
@@ -17,6 +17,7 @@
 package mekwars.common;
 
 import mekwars.common.campaign.CampaignOptions;
+import mekwars.common.campaign.HouseOptions;
 import mekwars.common.persistence.BannedAmmoStore;
 import mekwars.common.persistence.NamedEntityStore;
 import mekwars.common.util.BinReader;
@@ -27,10 +28,11 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Properties;
+import java.util.Map;
 import java.util.TreeMap;
 import java.util.Vector;
 
@@ -58,6 +60,7 @@ public class CampaignData implements TerrainProvider {
 
     private Vector<Integer> bannedTargetingSystems = new Vector<>();
     private HashMap<String, Integer> commands = new HashMap<>();
+    private Map<String, HouseOptions> houseOptionsMap = new HashMap<>();
     private TreeMap<String, String> planetOpFlags = new TreeMap<>();
 
     private BannedAmmoStore bannedAmmoStore = new BannedAmmoStore();
@@ -446,5 +449,26 @@ public class CampaignData implements TerrainProvider {
 
         // only one match! send it back.
         return theMatch;
+    }
+
+    /**
+     * Returns the HouseOptions for the given House.
+     *
+     * @return The {@link HouseOptions} for the given {@link House}
+     */
+    public HouseOptions getHouseOptions(String house) {
+        return houseOptionsMap.get(house);
+    }
+
+    /**
+     * @param path The path of the file to load from
+     * @param house The house to store the config for
+     */
+    public void loadHouseOptions(Path path, House house) {
+        if (houseOptionsMap.get(house.getName()) != null) {
+            return;
+        }
+
+        houseOptionsMap.put(house.getName(), new HouseOptions(path));
     }
 }

--- a/MekWarsCommon/src/mekwars/common/House.java
+++ b/MekWarsCommon/src/mekwars/common/House.java
@@ -645,4 +645,12 @@ public class House implements Entity {
     public boolean equals(House house) {
         return (house != null) && (getId() == house.getId());
     }
+
+    /**
+     * FIXME: On the client side there is no faction config. If the faction has any configurations
+     * they will be placed ontop of any existing configuration in the CampaignOptions.
+     */
+    public MekWarsConfig getHouseOptions() {
+        return CampaignData.cd.getHouseOptions(getName());
+    }
 }

--- a/MekWarsCommon/src/mekwars/common/MekWarsConfig.java
+++ b/MekWarsCommon/src/mekwars/common/MekWarsConfig.java
@@ -1,0 +1,230 @@
+/*
+ * MekWars - Copyright (C) 2026
+ *
+ * Derived from MegaMekNET (http://www.sourceforge.net/projects/megameknet)
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ */
+
+package mekwars.common;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Enumeration;
+import java.util.Properties;
+
+public abstract class MekWarsConfig {
+    private static final Logger LOGGER = LogManager.getLogger(MekWarsConfig.class);
+    private static final int TYPE_SIZE = Unit.AERO + 1;
+    private static final int WEIGHT_SIZE = Unit.ASSAULT + 1;
+
+    private int[][] unitLimits = new int[TYPE_SIZE][WEIGHT_SIZE];
+    private boolean[][] bmLimits = new boolean[TYPE_SIZE][WEIGHT_SIZE];
+    private Properties config = new Properties();
+    private Path path;
+
+    public MekWarsConfig(Path path) {
+        this.path = path;
+    }
+
+    public boolean getBooleanConfig(String key) {
+        try {
+            return Boolean.parseBoolean(this.getConfig(key));
+        } catch (Exception ex) {
+            return false;
+        }
+    }
+
+    public int getIntegerConfig(String key) {
+        try {
+            return Integer.parseInt(this.getConfig(key));
+        } catch (Exception ex) {
+            return -1;
+        }
+    }
+
+    public double getDoubleConfig(String key) {
+        try {
+            return Double.parseDouble(this.getConfig(key));
+        } catch (Exception ex) {
+            return -1;
+        }
+    }
+
+    public float getFloatConfig(String key) {
+        try {
+            return Float.parseFloat(this.getConfig(key));
+        } catch (Exception ex) {
+            return -1;
+        }
+    }
+
+    public long getLongConfig(String key) {
+        try {
+            return Long.parseLong(this.getConfig(key));
+        } catch (Exception ex) {
+            return -1;
+        }
+    }
+
+    public abstract String getConfig(String key);
+
+    protected Properties getConfig() {
+        return config;
+    }
+
+    /**
+     * A method that returns the hangar limit for a given weight/type of unit
+     *
+     * @param unitType
+     * @param unitWeightClass
+     * @return -1 if it is unlimited or a malformed request, the limit otherwise
+     */
+    public int getUnitLimit(int unitType, int unitWeight) {
+        if (unitType < 0 || unitType >= TYPE_SIZE || unitWeight < 0 || unitWeight >= WEIGHT_SIZE) {
+            LOGGER.error("Invalid get unit limit query: type={} weight={}", unitType, unitWeight);
+            return -1;
+        }
+        return unitLimits[unitType][unitWeight];
+    }
+
+    public boolean canBuyFromBM(int unitType, int unitWeight) {
+        if (unitType < 0 || unitType >= TYPE_SIZE || unitWeight < 0 || unitWeight >= WEIGHT_SIZE) {
+            LOGGER.error("Invalid BM limit query: type={} weight={}", unitType, unitWeight);
+            return false;
+        }
+        return bmLimits[unitType][unitWeight];
+    }
+
+    public void setCanBuyFromBM(int unitType, int unitWeight, boolean canBuy) {
+        if (unitType < 0 || unitType >= TYPE_SIZE || unitWeight < 0 || unitWeight >= WEIGHT_SIZE) {
+            LOGGER.error("Invalid BM set limit query: type={} weight={}", unitType, unitWeight);
+            return;
+        }
+
+        bmLimits[unitType][unitWeight] = canBuy;
+    }
+
+    public void save() {
+        long currentTime = System.currentTimeMillis();
+
+        /* NOTE: Some places expect the first 11 characters of a configuration to be #TIMESTAMP=
+         * followed by a timestamp, House configurations expect a TIMESTAMP property,
+         * here we do both.
+         */
+        setProperty("TIMESTAMP", Long.toString(currentTime));
+        try (OutputStream os = Files.newOutputStream(path);
+                BufferedOutputStream bos = new BufferedOutputStream(os);
+                PrintStream printStream = new PrintStream(bos, false, StandardCharsets.UTF_8)) {
+            printStream.println("#Timestamp=" + currentTime);
+            getConfig().store(printStream, "Server Config");
+            printStream.flush();
+        } catch (IOException exception) {
+            LOGGER.error("Unable to save config to {}", path, exception);
+        }
+    }
+
+    public void clear() {
+        config.clear();
+    }
+
+    public Enumeration<?> propertyNames() {
+        return config.propertyNames();
+    }
+
+    public void setProperty(String key, String value) {
+        config.setProperty(key, value);
+    }
+
+    public void load() throws IOException {
+        getConfig().load(Files.newInputStream(path));
+        onLoad();
+    }
+
+    public Path getPath() {
+        return path;
+    }
+
+    protected void onLoad() {
+        populateBMLimits();
+        populateUnitLimits();
+    }
+
+    /** A method to fill the unitLimits array */
+    private void populateUnitLimits() {
+        unitLimits[Unit.MEK][Unit.LIGHT] = getIntegerConfig("MaxHangarLightMek");
+        unitLimits[Unit.MEK][Unit.MEDIUM] = getIntegerConfig("MaxHangarMediumMek");
+        unitLimits[Unit.MEK][Unit.HEAVY] = getIntegerConfig("MaxHangarHeavyMek");
+        unitLimits[Unit.MEK][Unit.ASSAULT] = getIntegerConfig("MaxHangarAssaultMek");
+
+        unitLimits[Unit.VEHICLE][Unit.LIGHT] = getIntegerConfig("MaxHangarLightVehicle");
+        unitLimits[Unit.VEHICLE][Unit.MEDIUM] = getIntegerConfig("MaxHangarMediumVehicle");
+        unitLimits[Unit.VEHICLE][Unit.HEAVY] = getIntegerConfig("MaxHangarHeavyVehicle");
+        unitLimits[Unit.VEHICLE][Unit.ASSAULT] = getIntegerConfig("MaxHangarAssaultVehicle");
+
+        unitLimits[Unit.INFANTRY][Unit.LIGHT] = getIntegerConfig("MaxHangarLightInfantry");
+        unitLimits[Unit.INFANTRY][Unit.MEDIUM] = getIntegerConfig("MaxHangarMediumInfantry");
+        unitLimits[Unit.INFANTRY][Unit.HEAVY] = getIntegerConfig("MaxHangarHeavyInfantry");
+        unitLimits[Unit.INFANTRY][Unit.ASSAULT] = getIntegerConfig("MaxHangarAssaultInfantry");
+
+        unitLimits[Unit.PROTOMEK][Unit.LIGHT] = getIntegerConfig("MaxHangarLightProtoMek");
+        unitLimits[Unit.PROTOMEK][Unit.MEDIUM] = getIntegerConfig("MaxHangarMediumProtoMek");
+        unitLimits[Unit.PROTOMEK][Unit.HEAVY] = getIntegerConfig("MaxHangarHeavyProtoMek");
+        unitLimits[Unit.PROTOMEK][Unit.ASSAULT] = getIntegerConfig("MaxHangarAssaultProtoMek");
+
+        unitLimits[Unit.BATTLEARMOR][Unit.LIGHT] = getIntegerConfig("MaxHangarLightBattleArmor");
+        unitLimits[Unit.BATTLEARMOR][Unit.MEDIUM] = getIntegerConfig("MaxHangarMediumBattleArmor");
+        unitLimits[Unit.BATTLEARMOR][Unit.HEAVY] = getIntegerConfig("MaxHangarHeavyBattleArmor");
+        unitLimits[Unit.BATTLEARMOR][Unit.ASSAULT] =
+                getIntegerConfig("MaxHangarAssaultBattleArmor");
+
+        unitLimits[Unit.AERO][Unit.LIGHT] = getIntegerConfig("MaxHangarLightAero");
+        unitLimits[Unit.AERO][Unit.MEDIUM] = getIntegerConfig("MaxHangarMediumAero");
+        unitLimits[Unit.AERO][Unit.HEAVY] = getIntegerConfig("MaxHangarHeavyAero");
+        unitLimits[Unit.AERO][Unit.ASSAULT] = getIntegerConfig("MaxHangarAssaultAero");
+    }
+
+    private void populateBMLimits() {
+        bmLimits[Unit.MEK][Unit.LIGHT] = getBooleanConfig("CanBuyBMLightMeks");
+        bmLimits[Unit.MEK][Unit.MEDIUM] = getBooleanConfig("CanBuyBMMediumMeks");
+        bmLimits[Unit.MEK][Unit.HEAVY] = getBooleanConfig("CanBuyBMHeavyMeks");
+        bmLimits[Unit.MEK][Unit.ASSAULT] = getBooleanConfig("CanBuyBMAssaultMeks");
+
+        bmLimits[Unit.VEHICLE][Unit.LIGHT] = getBooleanConfig("CanBuyBMLightVehicles");
+        bmLimits[Unit.VEHICLE][Unit.MEDIUM] = getBooleanConfig("CanBuyBMMediumVehicles");
+        bmLimits[Unit.VEHICLE][Unit.HEAVY] = getBooleanConfig("CanBuyBMHeavyVehicles");
+        bmLimits[Unit.VEHICLE][Unit.ASSAULT] = getBooleanConfig("CanBuyBMAssaultVehicles");
+
+        bmLimits[Unit.INFANTRY][Unit.LIGHT] = getBooleanConfig("CanBuyBMLightInfantry");
+        bmLimits[Unit.INFANTRY][Unit.MEDIUM] = getBooleanConfig("CanBuyBMMediumInfantry");
+        bmLimits[Unit.INFANTRY][Unit.HEAVY] = getBooleanConfig("CanBuyBMHeavyInfantry");
+        bmLimits[Unit.INFANTRY][Unit.ASSAULT] = getBooleanConfig("CanBuyBMAssaultInfantry");
+
+        bmLimits[Unit.BATTLEARMOR][Unit.LIGHT] = getBooleanConfig("CanBuyBMLightBA");
+        bmLimits[Unit.BATTLEARMOR][Unit.MEDIUM] = getBooleanConfig("CanBuyBMMediumBA");
+        bmLimits[Unit.BATTLEARMOR][Unit.HEAVY] = getBooleanConfig("CanBuyBMHeavyBA");
+        bmLimits[Unit.BATTLEARMOR][Unit.ASSAULT] = getBooleanConfig("CanBuyBMAssaultBA");
+
+        bmLimits[Unit.PROTOMEK][Unit.LIGHT] = getBooleanConfig("CanBuyBMLightProtomeks");
+        bmLimits[Unit.PROTOMEK][Unit.MEDIUM] = getBooleanConfig("CanBuyBMMediumProtomeks");
+        bmLimits[Unit.PROTOMEK][Unit.HEAVY] = getBooleanConfig("CanBuyBMHeavyProtomeks");
+        bmLimits[Unit.PROTOMEK][Unit.ASSAULT] = getBooleanConfig("CanBuyBMAssaultProtomeks");
+
+        bmLimits[Unit.AERO][Unit.LIGHT] = getBooleanConfig("CanBuyBMLightAero");
+        bmLimits[Unit.AERO][Unit.MEDIUM] = getBooleanConfig("CanBuyBMMediumAero");
+        bmLimits[Unit.AERO][Unit.HEAVY] = getBooleanConfig("CanBuyBMHeavyAero");
+        bmLimits[Unit.AERO][Unit.ASSAULT] = getBooleanConfig("CanBuyBMAssaultAero");
+    }
+}

--- a/MekWarsCommon/src/mekwars/common/campaign/CampaignOptions.java
+++ b/MekWarsCommon/src/mekwars/common/campaign/CampaignOptions.java
@@ -12,59 +12,30 @@
 
 package mekwars.common.campaign;
 
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.FileNotFoundException;
-import java.io.PrintStream;
+import mekwars.common.MekWarsConfig;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Properties;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class CampaignOptions {
+public class CampaignOptions extends MekWarsConfig {
     private static final Logger LOGGER = LogManager.getLogger(CampaignOptions.class);
 
     private DefaultCampaignOptions defaultOptions;
-    private Properties config = new Properties();
 
-    public CampaignOptions(String configFile) {
+    public CampaignOptions(Path path) {
+        super(path);
         defaultOptions = new DefaultCampaignOptions();
         defaultOptions.createDefaults();
-        try {
-            config.putAll(defaultOptions.getDefaults()); // load all of the defaults
-            config.load(new FileInputStream(configFile));
-
-            // Right here, we're going to try to prune old cruft from the configs
-            // Over the course of many years, as config options change, crap never
-            // gets removed from campaignconfig.txt.  We're seeing this very badly on
-            // MMNet, and probably other servers are, as well.
-            ArrayList<String> keysToRemove = new ArrayList<String>();
-            for (Object key : config.keySet()) {
-                if (!defaultOptions.getDefaults().keySet().contains(key) && !((String)key).endsWith("RewardPointMultiplier")) {
-                    LOGGER.error("Key " + (String)key + " does not exist in DefaultServerConfig. Pruning from configs.");
-                    keysToRemove.add((String) key);
-                }
-            }
-
-            for (String key : keysToRemove) {
-                config.remove(key);
-            }
-            saveConfigureFile(config, configFile);
-        } catch (Exception ex) {
-            LOGGER.error("Problems with loading campaign config");
-            LOGGER.error("Exception: ", ex);
-            defaultOptions.createConfig(configFile);
-            try {
-                config.load(new FileInputStream(configFile));
-            } catch (Exception ex1) {
-                LOGGER.error("Problems with loading campaing config from defaults");
-                LOGGER.error(ex1);
-                System.exit(1);
-            }
-
-            // added
-            defaultOptions.createConfig(configFile); // save the cofig file so any missed defaults are
-        }
+        load();
+        // save the config file so any missed defaults are included.
+        save();
     }
 
     public boolean getBooleanConfig(String key) {
@@ -107,36 +78,58 @@ public class CampaignOptions {
         }
     }
 
+    public void load() {
+        // load all of the defaults
+        getConfig().putAll(defaultOptions.getDefaults());
+        try {
+            getConfig().load(Files.newInputStream(getPath()));
+
+            // Right here, we're going to try to prune old cruft from the configs
+            // Over the course of many years, as config options change, crap never
+            // gets removed from campaignconfig.txt.  We're seeing this very badly on
+            // MMNet, and probably other servers are, as well.
+            ArrayList<String> keysToRemove = new ArrayList<String>();
+            for (Object key : getConfig().keySet()) {
+                if (!defaultOptions.getDefaults().keySet().contains(key)
+                        && !((String) key).endsWith("RewardPointMultiplier")) {
+                    LOGGER.error(
+                            "Key "
+                                    + (String) key
+                                    + " does not exist in DefaultServerConfig. Pruning from"
+                                    + " configs.");
+                    keysToRemove.add((String) key);
+                }
+            }
+
+            for (String key : keysToRemove) {
+                getConfig().remove(key);
+            }
+            onLoad();
+        } catch (Exception ex) {
+            LOGGER.error("Problems with loading campaign config", ex);
+        }
+    }
+
+    @Override
     public String getConfig(String key) {
-        if (config.getProperty(key) == null) {
+        if (getConfig().getProperty(key) == null) {
             if (defaultOptions.getDefaults().getProperty(key) == null) {
                 LOGGER.error("You're missing the config variable: " + key + " in campaignconfig!");
                 return "-1";
             }
             return defaultOptions.getDefaults().getProperty(key).trim();
         }
-        return config.getProperty(key).trim();
+        return getConfig().getProperty(key).trim();
     }
 
     public void setProperty(String name, String value) {
-        config.setProperty(name, value);
+        getConfig().setProperty(name, value);
     }
 
+    /** Deprecated, use getConfig() instead. */
+    @Deprecated(since = "9.0.0", forRemoval = false)
     public Properties getProperties() {
-        return config;
-    }
-
-    public void saveConfigureFile(Properties config, String fileName) {
-        try {
-            PrintStream ps = new PrintStream(new FileOutputStream(fileName));
-            ps.println("#Timestamp=" + System.currentTimeMillis());
-            config.store(ps, "Server Config");
-            ps.close();
-        } catch (FileNotFoundException fe) {
-            LOGGER.error(fileName + " not found");
-        } catch (Exception ex) {
-            LOGGER.error("Exception: ", ex);
-        }
+        return getConfig();
     }
 
     public DefaultCampaignOptions getDefaultOptions() {

--- a/MekWarsCommon/src/mekwars/common/campaign/DefaultCampaignOptions.java
+++ b/MekWarsCommon/src/mekwars/common/campaign/DefaultCampaignOptions.java
@@ -1489,22 +1489,6 @@ public class DefaultCampaignOptions {
         defaults.setProperty("UseNewOpManager", "false");
     }
 
-    /**
-     * @author jtighe Saves the current server configs to the configfile.
-     */
-    public void createConfig(String filename) {
-        try {
-            CampaignData.cd
-                    .getCampaignOptions()
-                    .saveConfigureFile(
-                            CampaignData.cd.getCampaignOptions().getProperties(), filename);
-        } catch (Exception ex) {
-            LOGGER.error("Unable to save config file.");
-            LOGGER.error("Exception: ", ex);
-            LOGGER.error(ex.getMessage());
-        }
-    }
-
     public Properties getDefaults() {
         return defaults;
     }

--- a/MekWarsCommon/src/mekwars/common/campaign/HouseOptions.java
+++ b/MekWarsCommon/src/mekwars/common/campaign/HouseOptions.java
@@ -1,0 +1,44 @@
+/*
+ * MekWars - Copyright (C) 2026
+ *
+ * Derived from MegaMekNET (http://www.sourceforge.net/projects/megameknet)
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ */
+
+package mekwars.common.campaign;
+
+import mekwars.common.CampaignData;
+import mekwars.common.MekWarsConfig;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public class HouseOptions extends MekWarsConfig {
+    private static final Logger LOGGER = LogManager.getLogger(HouseOptions.class);
+
+    public HouseOptions(Path path) {
+        super(path);
+        try {
+            load();
+        // We want to eat the IOException here as this configuration is optional.
+        } catch(IOException exception) {
+            LOGGER.debug("Unable to find faction config {}", path, exception);
+        }
+    }
+
+    @Override
+    public String getConfig(String key) {
+        if (getConfig() == null || getConfig().getProperty(key) == null) {
+            return CampaignData.cd.getCampaignOptions().getConfig(key);
+        }
+        return getConfig().getProperty(key).trim();
+    }
+}

--- a/MekWarsCommon/src/mekwars/common/io/AbstractFileSystem.java
+++ b/MekWarsCommon/src/mekwars/common/io/AbstractFileSystem.java
@@ -94,6 +94,16 @@ public abstract class AbstractFileSystem {
     }
 
     /**
+     * Returns the path to a faction's config file.
+     *
+     * @return The path to a faction's config file.
+     */
+    public Path getFactionConfigPath(String faction) {
+        return FileSystems.getDefault()
+                .getPath(getDataDir().toString(), faction.toLowerCase() + "_configs.dat");
+    }
+
+    /**
      * Returns The path to the directory that contains all shared configurations.
      *
      * @return The path to the directory that contains all shared configurations.

--- a/MekWarsDedicatedHost/src/mekwars/dedicatedhost/protocol/DataFetchClient.java
+++ b/MekWarsDedicatedHost/src/mekwars/dedicatedhost/protocol/DataFetchClient.java
@@ -455,7 +455,7 @@ public class DataFetchClient {
     public CampaignData getAllData() throws IOException {
         BinReader in = openConnection("All");
         CampaignOptions campaignOptions =
-            new CampaignOptions(FileSystem.getInstance().getCampaignConfig().toString());
+            new CampaignOptions(FileSystem.getInstance().getCampaignConfig());
         CampaignData data = new CampaignData(campaignOptions, in);
         //in.close();
         this.data = data;
@@ -471,7 +471,7 @@ public class DataFetchClient {
     public CampaignData getCacheData(String cachePath) throws IOException {
         BinReader in = new BinReader(new FileReader(cachePath + "/data.dat"));
         CampaignOptions campaignOptions =
-            new CampaignOptions(FileSystem.getInstance().getCampaignConfig().toString());
+            new CampaignOptions(FileSystem.getInstance().getCampaignConfig());
         CampaignData data = new CampaignData(campaignOptions, in);
         in.close();
         this.data = data;

--- a/MekWarsServer/src/mekwars/server/MWServ.java
+++ b/MekWarsServer/src/mekwars/server/MWServ.java
@@ -1220,8 +1220,9 @@ public class MWServ {
         return banaccounts;
     }
     
+    @Deprecated(since = "9.0.0", forRemoval = false)
     public void saveConfigs() {
-        CampaignData.cd.getCampaignOptions().getDefaultOptions().createConfig(MWServ.getInstance().getConfigParam("CAMPAIGNCONFIG"));
+        CampaignData.cd.getCampaignOptions().save();
     }
 
     synchronized public void addToNewsFeed(String s) {

--- a/MekWarsServer/src/mekwars/server/campaign/CampaignMain.java
+++ b/MekWarsServer/src/mekwars/server/campaign/CampaignMain.java
@@ -208,7 +208,7 @@ public final class CampaignMain implements Serializable {
     public CampaignMain() {
         cm = this;
         CampaignOptions campaignOptions =
-            new CampaignOptions(FileSystem.getInstance().getCampaignConfig().toString());
+            new CampaignOptions(FileSystem.getInstance().getCampaignConfig());
 
         data = new CampaignData(campaignOptions);
 
@@ -247,7 +247,15 @@ public final class CampaignMain implements Serializable {
         loadFactionData();
         loadPlanetData();
 
-        FileSystem.getInstance().getBanAmmoFile().load(data);
+        if (Files.exists(FileSystem.getInstance().getBanAmmoPath())) {
+            FileSystem.getInstance().getBanAmmoFile().load(data);
+        }
+
+        for (House house : data.getAllHouses()) {
+            Path configPath = FileSystem.getInstance().getFactionConfigPath(house.getName());
+
+            CampaignData.cd.loadHouseOptions(configPath, house);
+        }
 
         // misc loads.
         cm.loadOmniVariantMods();
@@ -2869,11 +2877,6 @@ public final class CampaignMain implements Serializable {
     public boolean isArchiving() {
         return isArchiving;
     }
-
-    @Deprecated(since = "9.0.0", forRemoval = false)
-    public void saveConfigureFile(Properties config, String fileName) {
-        getCampaignOptions().saveConfigureFile(config, fileName);
-    } // end saveConfigureFile
 
     public UnitCosts getUnitCostLists() {
         return cm.unitCostLists;

--- a/MekWarsServer/src/mekwars/server/campaign/SHouse.java
+++ b/MekWarsServer/src/mekwars/server/campaign/SHouse.java
@@ -20,10 +20,8 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.PrintStream;
 import java.io.Serializable;
 import java.text.DecimalFormat;
 import java.util.Collections;
@@ -32,7 +30,6 @@ import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.LinkedList;
-import java.util.Properties;
 import java.util.Random;
 import java.util.StringTokenizer;
 import java.util.Vector;
@@ -102,16 +99,12 @@ public class SHouse extends TimeUpdateHouse implements Comparable<Object>, ISell
     private PilotQueues pilotQueues = new PilotQueues(getBaseGunnerVect(), getBasePilotVect(), getBasePilotSkillVect());
 
     private boolean inHouseAttacks = false;
-    private Properties config = new Properties();
 
     private Vector<String> leaders = new Vector<String>(1, 1);
     private int techResearchPoints = 0;
     private UnitComponents unitParts = new UnitComponents();
     private Hashtable<String, ComponentToCritsConverter> componentConverter = new Hashtable<String, ComponentToCritsConverter>();
 
-    private int[][] unitLimits = new int[6][4];
-    private boolean[][] bmLimits = new boolean[6][4];
-    
     private double activityPP = 0.0;
     
     @Override
@@ -689,9 +682,7 @@ public class SHouse extends TimeUpdateHouse implements Comparable<Object>, ISell
              * this.getPilotQueues().setBasePiloting(this.getBasePilot());
              */
 
-            loadConfigFile();
             setUsedMekBayMultiplier(Float.parseFloat(getConfig("UsedPurchaseCostMulti")));
-
             return s;
         } catch (Exception ex) {
             LOGGER.error("Exception: ", ex);
@@ -2646,169 +2637,7 @@ public class SHouse extends TimeUpdateHouse implements Comparable<Object>, ISell
 
     }
 
-    public Properties getConfig() {
-        return config;
-    }
-
-    public boolean getBooleanConfig(String key) {
-        try {
-            return Boolean.parseBoolean(this.getConfig(key));
-        } catch (Exception ex) {
-            return false;
-        }
-    }
-
-    public int getIntegerConfig(String key) {
-        try {
-            return Integer.parseInt(this.getConfig(key));
-        } catch (Exception ex) {
-            return -1;
-        }
-    }
-
-    public double getDoubleConfig(String key) {
-        try {
-            return Double.parseDouble(this.getConfig(key));
-        } catch (Exception ex) {
-            return -1;
-        }
-    }
-
-    public float getFloatConfig(String key) {
-        try {
-            return Float.parseFloat(this.getConfig(key));
-        } catch (Exception ex) {
-            return -1;
-        }
-    }
-
-    public float getLongConfig(String key) {
-        try {
-            return Long.parseLong(this.getConfig(key));
-        } catch (Exception ex) {
-            return -1;
-        }
-    }
-
-    public String getConfig(String key) {
-
-        if (config == null || config.getProperty(key) == null) {
-            return CampaignMain.cm.getConfig(key);
-        }
-        return config.getProperty(key).trim();
-    }
-
-    public void saveConfigFile() {
-
-        if (config == null) {
-            return;
-        }
-
-        if (config.size() < 1) {
-            config = null;
-            return;
-        }
-
-        String fileName = "./data/" + getName().toLowerCase() + "_configs.dat";
-        try {
-            config.setProperty("TIMESTAMP", Long.toString((System.currentTimeMillis())));
-            PrintStream ps = new PrintStream(new FileOutputStream(fileName));
-            config.store(ps, "Faction Config");
-            ps.close();
-        } catch (FileNotFoundException fe) {
-            LOGGER.error(fileName + " not found");
-        } catch (Exception ex) {
-            LOGGER.error("Exception: ", ex);
-        }
-
-    }
-
-    public void loadConfigFile() {
-
-        File configFile = new File("./data/" + getName().toLowerCase() + "_configs.dat");
-
-        if (!configFile.exists()) {
-            populateUnitLimits();
-            populateBMLimits();
-            return;
-        }
-
-        try {
-            config = new Properties();
-            config.load(new FileInputStream(configFile));
-            populateUnitLimits();
-        } catch (Exception ex) {
-            LOGGER.error("Exception: ", ex);
-        }
-        populateUnitLimits();
-        populateBMLimits();
-    }
-
-    /**
-     * A method to fill the unitLimits array
-     */
-    public void populateUnitLimits() {
-        unitLimits[Unit.MEK][Unit.LIGHT] = getIntegerConfig("MaxHangarLightMek");
-        unitLimits[Unit.MEK][Unit.MEDIUM] = getIntegerConfig("MaxHangarMediumMek");
-        unitLimits[Unit.MEK][Unit.HEAVY] = getIntegerConfig("MaxHangarHeavyMek");
-        unitLimits[Unit.MEK][Unit.ASSAULT] = getIntegerConfig("MaxHangarAssaultMek");
-
-        unitLimits[Unit.VEHICLE][Unit.LIGHT] = getIntegerConfig("MaxHangarLightVehicle");
-        unitLimits[Unit.VEHICLE][Unit.MEDIUM] = getIntegerConfig("MaxHangarMediumVehicle");
-        unitLimits[Unit.VEHICLE][Unit.HEAVY] = getIntegerConfig("MaxHangarHeavyVehicle");
-        unitLimits[Unit.VEHICLE][Unit.ASSAULT] = getIntegerConfig("MaxHangarAssaultVehicle");
-
-        unitLimits[Unit.INFANTRY][Unit.LIGHT] = getIntegerConfig("MaxHangarLightInfantry");
-        unitLimits[Unit.INFANTRY][Unit.MEDIUM] = getIntegerConfig("MaxHangarMediumInfantry");
-        unitLimits[Unit.INFANTRY][Unit.HEAVY] = getIntegerConfig("MaxHangarHeavyInfantry");
-        unitLimits[Unit.INFANTRY][Unit.ASSAULT] = getIntegerConfig("MaxHangarAssaultInfantry");
-
-        unitLimits[Unit.BATTLEARMOR][Unit.LIGHT] = getIntegerConfig("MaxHangarLightBattleArmor");
-        unitLimits[Unit.BATTLEARMOR][Unit.MEDIUM] = getIntegerConfig("MaxHangarMediumBattleArmor");
-        unitLimits[Unit.BATTLEARMOR][Unit.HEAVY] = getIntegerConfig("MaxHangarHeavyBattleArmor");
-        unitLimits[Unit.BATTLEARMOR][Unit.ASSAULT] = getIntegerConfig("MaxHangarAssaultBattleArmor");
-
-        unitLimits[Unit.PROTOMEK][Unit.LIGHT] = getIntegerConfig("MaxHangarLightProtoMek");
-        unitLimits[Unit.PROTOMEK][Unit.MEDIUM] = getIntegerConfig("MaxHangarMediumProtoMek");
-        unitLimits[Unit.PROTOMEK][Unit.HEAVY] = getIntegerConfig("MaxHangarHeavyProtoMek");
-        unitLimits[Unit.PROTOMEK][Unit.ASSAULT] = getIntegerConfig("MaxHangarAssaultProtoMek");
-
-        unitLimits[Unit.AERO][Unit.LIGHT] = getIntegerConfig("MaxHangarLightAero");
-        unitLimits[Unit.AERO][Unit.MEDIUM] = getIntegerConfig("MaxHangarMediumAero");
-        unitLimits[Unit.AERO][Unit.HEAVY] = getIntegerConfig("MaxHangarHeavyAero");
-        unitLimits[Unit.AERO][Unit.ASSAULT] = getIntegerConfig("MaxHangarAssaultAero");
-    }
-
-    /**
-     * A method that returns the hangar limit for a given weight/type of unit
-     * 
-     * @param unitType
-     * @param unitWeightClass
-     * @return -1 if it is unlimited or a malformed request, the limit otherwise
-     */
-    public int getUnitLimit(int unitType, int unitWeightClass) {
-        if (unitType < 0 || unitType > Unit.AERO) {
-            LOGGER.error("Request for invalid unitType in SHouse.getUnitLimit: " + unitType);
-            return -1;
-        }
-        if (unitWeightClass < 0 || unitWeightClass > Unit.ASSAULT) {
-            LOGGER.error("Request for invalid unitWeightClass in SHouse.getUnitLimit: " + unitWeightClass);
-            return -1;
-        }
-        return unitLimits[unitType][unitWeightClass];
-    }
-
-        
-    public boolean canBuyFromBM(int unitType, int unitWeight) {
-        return bmLimits[unitType][unitWeight];
-    }
-    
-    public void setCanBuyFromBM(int unitType, int unitWeight, boolean canBuy) {
-        bmLimits[unitType][unitWeight] = canBuy;
-    }
-
     public void sendMessageToHouseLeaders(String msg) {
-
         if (leaders.size() < 1) {
             return;
         }
@@ -3172,38 +3001,34 @@ public class SHouse extends TimeUpdateHouse implements Comparable<Object>, ISell
         }
 
     }
-    
-    public void populateBMLimits() {
-        bmLimits[Unit.MEK][Unit.LIGHT] = getBooleanConfig("CanBuyBMLightMeks");
-        bmLimits[Unit.MEK][Unit.MEDIUM] = getBooleanConfig("CanBuyBMMediumMeks");
-        bmLimits[Unit.MEK][Unit.HEAVY] = getBooleanConfig("CanBuyBMHeavyMeks");
-        bmLimits[Unit.MEK][Unit.ASSAULT] = getBooleanConfig("CanBuyBMAssaultMeks");
 
-        bmLimits[Unit.VEHICLE][Unit.LIGHT] = getBooleanConfig("CanBuyBMLightVehicles");
-        bmLimits[Unit.VEHICLE][Unit.MEDIUM] = getBooleanConfig("CanBuyBMMediumVehicles");
-        bmLimits[Unit.VEHICLE][Unit.HEAVY] = getBooleanConfig("CanBuyBMHeavyVehicles");
-        bmLimits[Unit.VEHICLE][Unit.ASSAULT] = getBooleanConfig("CanBuyBMAssaultVehicles");
-
-        bmLimits[Unit.INFANTRY][Unit.LIGHT] = getBooleanConfig("CanBuyBMLightInfantry");
-        bmLimits[Unit.INFANTRY][Unit.MEDIUM] = getBooleanConfig("CanBuyBMMediumInfantry");
-        bmLimits[Unit.INFANTRY][Unit.HEAVY] = getBooleanConfig("CanBuyBMHeavyInfantry");
-        bmLimits[Unit.INFANTRY][Unit.ASSAULT] = getBooleanConfig("CanBuyBMAssaultInfantry");
-
-        bmLimits[Unit.BATTLEARMOR][Unit.LIGHT] = getBooleanConfig("CanBuyBMLightBA");
-        bmLimits[Unit.BATTLEARMOR][Unit.MEDIUM] = getBooleanConfig("CanBuyBMMediumBA");
-        bmLimits[Unit.BATTLEARMOR][Unit.HEAVY] = getBooleanConfig("CanBuyBMHeavyBA");
-        bmLimits[Unit.BATTLEARMOR][Unit.ASSAULT] = getBooleanConfig("CanBuyBMAssaultBA");
-
-        bmLimits[Unit.PROTOMEK][Unit.LIGHT] = getBooleanConfig("CanBuyBMLightProtomeks");
-        bmLimits[Unit.PROTOMEK][Unit.MEDIUM] = getBooleanConfig("CanBuyBMMediumProtomeks");
-        bmLimits[Unit.PROTOMEK][Unit.HEAVY] = getBooleanConfig("CanBuyBMHeavyProtomeks");
-        bmLimits[Unit.PROTOMEK][Unit.ASSAULT] = getBooleanConfig("CanBuyBMAssaultProtomeks");
-
-        bmLimits[Unit.AERO][Unit.LIGHT] = getBooleanConfig("CanBuyBMLightAero");
-        bmLimits[Unit.AERO][Unit.MEDIUM] = getBooleanConfig("CanBuyBMMediumAero");
-        bmLimits[Unit.AERO][Unit.HEAVY] = getBooleanConfig("CanBuyBMHeavyAero");
-        bmLimits[Unit.AERO][Unit.ASSAULT] = getBooleanConfig("CanBuyBMAssaultAero");
-
+    @Deprecated(since = "9.0.0", forRemoval = false) 
+    public String getConfig(String key) {
+        return getHouseOptions().getConfig(key);
     }
-    
+
+    @Deprecated(since = "9.0.0", forRemoval = false) 
+    public boolean getBooleanConfig(String key) {
+        return getHouseOptions().getBooleanConfig(key);
+    }
+
+    @Deprecated(since = "9.0.0", forRemoval = false) 
+    public int getIntegerConfig(String key) {
+        return getHouseOptions().getIntegerConfig(key);
+    }
+
+    @Deprecated(since = "9.0.0", forRemoval = false) 
+    public double getDoubleConfig(String key) {
+        return getHouseOptions().getDoubleConfig(key);
+    }
+
+    @Deprecated(since = "9.0.0", forRemoval = false) 
+    public float getFloatConfig(String key) {
+        return getHouseOptions().getFloatConfig(key);
+    }
+
+    @Deprecated(since = "9.0.0", forRemoval = false) 
+    public long getLongConfig(String key) {
+        return getHouseOptions().getLongConfig(key);
+    }
 }// end SHouse.java

--- a/MekWarsServer/src/mekwars/server/campaign/SPlayer.java
+++ b/MekWarsServer/src/mekwars/server/campaign/SPlayer.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.StringTokenizer;
 import java.util.Vector;
 
+import mekwars.common.CampaignData;
 import mekwars.common.Player;
 import mekwars.common.SubFaction;
 import mekwars.common.Unit;
@@ -3976,7 +3977,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
             LOGGER.error("Invalid uWeightClass in SPlayer.hasRoomForUnit: " + uWeightClass);
             return false;
         }
-        int limit = CampaignMain.cm.getHouseFromPartialString(getMyHouse().getName()).getUnitLimit(uType, uWeightClass);
+        int limit = CampaignData.cd.getCampaignOptions().getUnitLimit(uType, uWeightClass);
 
         if (limit < 0) {
             // Unlimited
@@ -4031,7 +4032,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     public boolean isOverAnyUnitLimits() {
         for (int t = Unit.MEK; t <= Unit.AERO; t++) {
             for (int w = Unit.LIGHT; w <= Unit.ASSAULT; w++) {
-                int limit = getMyHouse().getUnitLimit(t, w);
+                int limit = CampaignData.cd.getCampaignOptions().getUnitLimit(t, w);
                 int inHangar = countUnits(t, w);
                 if ((limit != -1) && (inHangar > limit)) {
                     return true;
@@ -4062,7 +4063,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
         {
             for (int w = Unit.LIGHT; w <= Unit.ASSAULT; w++)
             {
-                int limit = getMyHouse().getUnitLimit(t, w);
+                int limit = CampaignData.cd.getCampaignOptions().getUnitLimit(t, w);
                 int inHangar = countUnits(t, w);
 
                 if(limit != -1)
@@ -4098,7 +4099,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
         {
             for (int w = Unit.LIGHT; w <= Unit.ASSAULT; w++)
             {
-                int limit = getMyHouse().getUnitLimit(t, w);
+                int limit = CampaignData.cd.getCampaignOptions().getUnitLimit(t, w);
                 int inHangar = countUnits(t, w);
 
                 if(limit != -1)
@@ -4125,7 +4126,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     		return false;
     	}
 
-    	int limit = CampaignMain.cm.getHouseFromPartialString(getMyHouse().getName()).getUnitLimit(uType, uWeight);
+    	int limit = CampaignData.cd.getCampaignOptions().getUnitLimit(uType, uWeight);
 
     	// Always false if the particular limit is not checked
     	if (limit < 0) {
@@ -4155,7 +4156,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     		return false;
     	}
 
-    	int limit = CampaignMain.cm.getHouseFromPartialString(getMyHouse().getName()).getUnitLimit(uType, uWeight);
+        int limit = CampaignData.cd.getCampaignOptions().getUnitLimit(uType, uWeight);
 
     	// Always false if the particular limit is not checked
     	if (limit < 0) {
@@ -4195,7 +4196,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     public int calculateHangarPenaltyForNextPurchase(int type, int weight) {
     	int penalty = 0;
 
-		int limit = CampaignMain.cm.getHouseFromPartialString(getMyHouse().getName()).getUnitLimit(type, weight);
+        int limit = CampaignData.cd.getCampaignOptions().getUnitLimit(type, weight);
 		int numUnits = countUnits(type, weight) + 1;
 
 		if ((limit == -1) || (numUnits <= limit)) {
@@ -4216,7 +4217,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
 		}
 		int penalty = 0;
 
-		int limit = CampaignMain.cm.getHouseFromPartialString(getMyHouse().getName()).getUnitLimit(type_id, weightclass);
+        int limit = CampaignData.cd.getCampaignOptions().getUnitLimit(type_id, weightclass);
 		int numUnits = countUnits(type_id, weightclass);
 
 		if (numUnits <= limit) {

--- a/MekWarsServer/src/mekwars/server/campaign/commands/BidCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/BidCommand.java
@@ -18,6 +18,7 @@ package mekwars.server.campaign.commands;
 
 import java.util.StringTokenizer;
 
+import mekwars.common.CampaignData;
 import mekwars.common.Unit;
 import mekwars.server.MWServ;
 import mekwars.server.campaign.CampaignMain;
@@ -103,7 +104,7 @@ public class  BidCommand  implements Command {
 		// Check that the house is allowed to bid on this type of unit
 		int uType = auction.getUnitType();
 		int uWeight = auction.getUnitWeight();
-		boolean canBuy = CampaignMain.cm.getHouseForPlayer(p.getName()).canBuyFromBM(uType, uWeight);
+        boolean canBuy = CampaignData.cd.getCampaignOptions().canBuyFromBM(uType, uWeight);
 //		boolean canBuy = p.getMyHouse().canBuyFromBM(uType, uWeight);
 		if (!canBuy) {
 			CampaignMain.cm.toUser("AM:Your faction is not allowed to purchase " + 

--- a/MekWarsServer/src/mekwars/server/campaign/commands/GetFactionConfigsCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/GetFactionConfigsCommand.java
@@ -1,6 +1,6 @@
 /*
- * MekWars - Copyright (C) 2007 
- * 
+ * MekWars - Copyright (C) 2007
+ *
  * Original author - Torren (torren@users.sourceforge.net)
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -16,24 +16,25 @@
 
 /*
  * Created on 02.25.2007
- *  
+ *
  */
 package mekwars.server.campaign.commands;
-
-import java.util.Enumeration;
-import java.util.StringTokenizer;
 
 import mekwars.common.util.TokenReader;
 import mekwars.server.MWServ;
 import mekwars.server.campaign.CampaignMain;
 import mekwars.server.campaign.SHouse;
 import mekwars.server.campaign.SPlayer;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Enumeration;
+import java.util.StringTokenizer;
+
 /**
- * @author Torren (Jason Tighe) Send a factions config to the player. Optional
- *         Faction Name variable for Staff to pull different factions configs.
+ * @author Torren (Jason Tighe) Send a factions config to the player. Optional Faction Name variable
+ *     for Staff to pull different factions configs.
  */
 public class GetFactionConfigsCommand implements Command {
     private static final Logger LOGGER = LogManager.getLogger(GetFactionConfigsCommand.class);
@@ -49,22 +50,27 @@ public class GetFactionConfigsCommand implements Command {
         return 0;
     }
 
-    public void setExecutionLevel(int i) {
-    }
+    public void setExecutionLevel(int i) {}
 
-    public void process(StringTokenizer command, String Username) {
-
+    public void process(StringTokenizer command, String username) {
         try {
             if (accessLevel != 0) {
-                int userLevel = MWServ.getInstance().getUserLevel(Username);
+                int userLevel = MWServ.getInstance().getUserLevel(username);
                 if (userLevel < getExecutionLevel()) {
-                    CampaignMain.cm.toUser("AM:Insufficient access level for command. Level: " + userLevel + ". Required: " + accessLevel + ".", Username, true);
-                    CampaignMain.cm.toUser("PL|FC|DONE#DONE", Username, false);
+                    CampaignMain.cm.toUser(
+                            "AM:Insufficient access level for command. Level: "
+                                    + userLevel
+                                    + ". Required: "
+                                    + accessLevel
+                                    + ".",
+                            username,
+                            true);
+                    CampaignMain.cm.toUser("PL|FC|DONE#DONE", username, false);
                     return;
                 }
             }
 
-            SPlayer player = CampaignMain.cm.getPlayer(Username);
+            SPlayer player = CampaignMain.cm.getPlayer(username);
             String factionName = player.getMyHouse().getName();
             SHouse faction = null;
             long timeStamp = -1;
@@ -72,7 +78,7 @@ public class GetFactionConfigsCommand implements Command {
             try {
                 timeStamp = TokenReader.readLong(command);
             } catch (Exception ex) {
-                CampaignMain.cm.toUser("PL|FC|DONE#DONE", Username, false);
+                CampaignMain.cm.toUser("PL|FC|DONE#DONE", username, false);
                 return;
             }
 
@@ -82,8 +88,8 @@ public class GetFactionConfigsCommand implements Command {
 
             faction = CampaignMain.cm.getHouseFromPartialString(factionName);
 
-            if (faction == null || faction.getConfig() == null) {
-                CampaignMain.cm.toUser("PL|FC|DONE#DONE", Username, false);
+            if (faction == null || faction.getHouseOptions() == null) {
+                CampaignMain.cm.toUser("PL|FC|DONE#DONE", username, false);
                 return;
             }
 
@@ -92,14 +98,14 @@ public class GetFactionConfigsCommand implements Command {
              * AdminMenu causes it to fully update each time.
              */
             if (timeStamp >= faction.getLongConfig("TIMESTAMP")) {
-                CampaignMain.cm.toUser("PL|FC|DONE#DONE", Username, false);
+                CampaignMain.cm.toUser("PL|FC|DONE#DONE", username, false);
                 return;
             }
 
             StringBuffer result = new StringBuffer("PL|FC|");
             String delimiter = "#";
 
-            Enumeration<Object> keys = faction.getConfig().keys();
+            Enumeration<?> keys = faction.getHouseOptions().propertyNames();
             while (keys.hasMoreElements()) {
                 String key = (String) keys.nextElement();
                 String value = faction.getConfig(key);
@@ -107,13 +113,13 @@ public class GetFactionConfigsCommand implements Command {
                 result.append(delimiter);
                 result.append(value);
                 result.append(delimiter);
-            }// End While
+            } // End While
 
             result.append("DONE#DONE");
-            CampaignMain.cm.toUser(result.toString(), Username, false);
+            CampaignMain.cm.toUser(result.toString(), username, false);
         } catch (Exception ex) {
-            CampaignMain.cm.toUser("PL|FC|DONE#DONE", Username, false);
+            CampaignMain.cm.toUser("PL|FC|DONE#DONE", username, false);
             LOGGER.error("Exception: ", ex);
         }
     }
-}// end GetFactionConfigsCommand 
+}

--- a/MekWarsServer/src/mekwars/server/campaign/commands/admin/AdminChangeFactionConfigCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/admin/AdminChangeFactionConfigCommand.java
@@ -1,6 +1,6 @@
 /*
- * MekWars - Copyright (C) 2007 
- * 
+ * MekWars - Copyright (C) 2007
+ *
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -14,48 +14,60 @@
  */
 
 /**
- * @author jtighe
- * This Command is used bye server admins to change config items on the fly
- * while the server is still running.
- * 
+ * @author jtighe This Command is used bye server admins to change config items on the fly while the
+ *     server is still running.
  */
 package mekwars.server.campaign.commands.admin;
 
-import java.util.StringTokenizer;
-import mekwars.server.MWServ;
 import mekwars.server.MWChatServer.auth.IAuthenticator;
+import mekwars.server.MWServ;
 import mekwars.server.campaign.CampaignMain;
 import mekwars.server.campaign.SHouse;
 import mekwars.server.campaign.commands.Command;
 
+import java.util.StringTokenizer;
+
 public class AdminChangeFactionConfigCommand implements Command {
-	
-	int accessLevel = IAuthenticator.ADMIN;
-	String syntax = "house#config#arg";
-	public int getExecutionLevel(){return accessLevel;}
-	public void setExecutionLevel(int i) {accessLevel = i;}
-	public String getSyntax() { return syntax;}
-	
-	public void process(StringTokenizer command,String Username) {
-		
-		//access level check
-		int userLevel = MWServ.getInstance().getUserLevel(Username);
-		if(userLevel < getExecutionLevel()) {
-			CampaignMain.cm.toUser("AM:Insufficient access level for command. Level: " + userLevel + ". Required: " + accessLevel + ".",Username,true);
-			return;
-		}
-		
-		//get config var and new setting
-		String house = command.nextToken();
-		String config = command.nextToken();
-		String arg = command.nextToken();
-		
-		SHouse h = CampaignMain.cm.getHouseFromPartialString(house);
-		//make setting change
-		h.getConfig().setProperty(config,arg);
-		
-		//NOTE:
-		//NO MODMAIL for setting changes. Server Config GUI would spam too much.
-		
-	}//end process
+    int accessLevel = IAuthenticator.ADMIN;
+    String syntax = "house#config#arg";
+
+    public int getExecutionLevel() {
+        return accessLevel;
+    }
+
+    public void setExecutionLevel(int i) {
+        accessLevel = i;
+    }
+
+    public String getSyntax() {
+        return syntax;
+    }
+
+    public void process(StringTokenizer command, String username) {
+        // access level check
+        int userLevel = MWServ.getInstance().getUserLevel(username);
+        if (userLevel < getExecutionLevel()) {
+            CampaignMain.cm.toUser(
+                    "AM:Insufficient access level for command. Level: "
+                            + userLevel
+                            + ". Required: "
+                            + accessLevel
+                            + ".",
+                    username,
+                    true);
+            return;
+        }
+
+        // get config var and new setting
+        String house = command.nextToken();
+        String config = command.nextToken();
+        String arg = command.nextToken();
+
+        SHouse h = CampaignMain.cm.getHouseFromPartialString(house);
+        // make setting change
+        h.getHouseOptions().setProperty(config, arg);
+
+        // NOTE:
+        // NO MODMAIL for setting changes. Server Config GUI would spam too much.
+    }
 }

--- a/MekWarsServer/src/mekwars/server/campaign/commands/admin/AdminPurgeHouseConfigsCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/admin/AdminPurgeHouseConfigsCommand.java
@@ -1,6 +1,6 @@
 /*
- * MekWars - Copyright (C) 2007 
- * 
+ * MekWars - Copyright (C) 2007
+ *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 2 of the License, or (at your option)
@@ -14,56 +14,84 @@
 
 package mekwars.server.campaign.commands.admin;
 
-
-import java.io.File;
-import java.util.StringTokenizer;
-import mekwars.server.MWServ;
 import mekwars.server.MWChatServer.auth.IAuthenticator;
+import mekwars.server.MWServ;
 import mekwars.server.campaign.CampaignMain;
 import mekwars.server.campaign.SHouse;
 import mekwars.server.campaign.commands.Command;
+import mekwars.server.io.FileSystem;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.StringTokenizer;
 
 public class AdminPurgeHouseConfigsCommand implements Command {
-	
-	int accessLevel = IAuthenticator.ADMIN;
-	String syntax = "Faction Name";
-	public int getExecutionLevel(){return accessLevel;}
-	public void setExecutionLevel(int i) {accessLevel = i;}
-	public String getSyntax() { return syntax;}
-	
-	public void process(StringTokenizer command,String Username) {
-		
-		//access level check
-		int userLevel = MWServ.getInstance().getUserLevel(Username);
-		if(userLevel < getExecutionLevel()) {
-		    CampaignMain.cm.toUser("AM:Insufficient access level for command. Level: " + userLevel + ". Required: " + accessLevel + ".",Username,true);
-		    return;
-		}
-		
-		String faction = "";
-        
-		try{
-		    faction = command.nextToken();
-		}
-		catch (Exception ex){
-		    CampaignMain.cm.toUser("Invalid syntax. Try: AdminPurgeHouseConfig#faction",Username,true);
-		    return;
-		}
-		
-		SHouse h = CampaignMain.cm.getHouseFromPartialString(faction,Username);
-		
-		if ( h == null )
-		    return;
+    private static final Logger LOGGER = LogManager.getLogger(AdminPurgeHouseConfigsCommand.class);
 
-		h.getConfig().clear();
-		File fp = new File("./campaign/factions/" + h.getName().toLowerCase() + "_configs.dat");
-		
-		if ( fp.exists() )
-			fp.delete();
-		
-		h.saveConfigFile();
-		
-		h.updated();
-        CampaignMain.cm.doSendModMail("NOTE",Username+" has purged campaign configs for "+h.getName());
-	}
-}// end AdminPurgeHouseConfigsCommand
+    int accessLevel = IAuthenticator.ADMIN;
+    String syntax = "Faction Name";
+
+    public int getExecutionLevel() {
+        return accessLevel;
+    }
+
+    public void setExecutionLevel(int i) {
+        accessLevel = i;
+    }
+
+    public String getSyntax() {
+        return syntax;
+    }
+
+    public void process(StringTokenizer command, String username) {
+        // access level check
+        int userLevel = MWServ.getInstance().getUserLevel(username);
+        if (userLevel < getExecutionLevel()) {
+            CampaignMain.cm.toUser(
+                    "AM:Insufficient access level for command. Level: "
+                            + userLevel
+                            + ". Required: "
+                            + accessLevel
+                            + ".",
+                    username,
+                    true);
+            return;
+        }
+
+        String faction = "";
+
+        try {
+            faction = command.nextToken();
+        } catch (Exception ex) {
+            CampaignMain.cm.toUser(
+                    "Invalid syntax. Try: AdminPurgeHouseConfig#faction", username, true);
+            return;
+        }
+
+        SHouse h = CampaignMain.cm.getHouseFromPartialString(faction, username);
+
+        if (h == null) {
+            return;
+        }
+
+        h.getHouseOptions().clear();
+        Path path = FileSystem.getInstance().getFactionConfigPath(h.getName());
+
+        try {
+            if (Files.exists(path)) {
+                Files.delete(path);
+
+                h.updated();
+                CampaignMain.cm.doSendModMail(
+                        "NOTE", username + " has purged campaign configs for " + h.getName());
+            }
+        } catch (IOException exception) {
+            LOGGER.error("Unable to delete file {}", path.toString(), exception);
+            CampaignMain.cm.toUser("Unable to delete faction configs for " + h.getName(), username);
+        }
+    }
+}

--- a/MekWarsServer/src/mekwars/server/campaign/commands/admin/AdminReloadHouseConfigsCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/admin/AdminReloadHouseConfigsCommand.java
@@ -1,6 +1,6 @@
 /*
- * MekWars - Copyright (C) 2007 
- * 
+ * MekWars - Copyright (C) 2007
+ *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 2 of the License, or (at your option)
@@ -14,49 +14,77 @@
 
 package mekwars.server.campaign.commands.admin;
 
-
-import java.util.StringTokenizer;
-import mekwars.server.MWServ;
 import mekwars.server.MWChatServer.auth.IAuthenticator;
+import mekwars.server.MWServ;
 import mekwars.server.campaign.CampaignMain;
 import mekwars.server.campaign.SHouse;
 import mekwars.server.campaign.commands.Command;
 
-public class AdminReloadHouseConfigsCommand implements Command {
-	
-	int accessLevel = IAuthenticator.ADMIN;
-	String syntax = "Faction Name";
-	public int getExecutionLevel(){return accessLevel;}
-	public void setExecutionLevel(int i) {accessLevel = i;}
-	public String getSyntax() { return syntax;}
-	
-	public void process(StringTokenizer command,String Username) {
-		
-		//access level check
-		int userLevel = MWServ.getInstance().getUserLevel(Username);
-		if(userLevel < getExecutionLevel()) {
-		    CampaignMain.cm.toUser("AM:Insufficient access level for command. Level: " + userLevel + ". Required: " + accessLevel + ".",Username,true);
-		    return;
-		}
-		
-		String faction = "";
-        
-		try{
-		    faction = command.nextToken();
-		}
-		catch (Exception ex){
-		    CampaignMain.cm.toUser("Invalid syntax. Try: AdminReloadHouseConfig#faction",Username,true);
-		    return;
-		}
-		
-		SHouse h = CampaignMain.cm.getHouseFromPartialString(faction,Username);
-		
-		if ( h == null )
-		    return;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-		h.getConfig().clear();
-		h.loadConfigFile();
-		h.updated();
-        CampaignMain.cm.doSendModMail("NOTE",Username+" has reloaded campaign configs for "+h.getName());
-	}
-}// end AdminReloadHouseconfigsCommand
+import java.io.IOException;
+import java.util.StringTokenizer;
+
+public class AdminReloadHouseConfigsCommand implements Command {
+    private static final Logger LOGGER = LogManager.getLogger(AdminReloadHouseConfigsCommand.class);
+
+    int accessLevel = IAuthenticator.ADMIN;
+    String syntax = "Faction Name";
+
+    public int getExecutionLevel() {
+        return accessLevel;
+    }
+
+    public void setExecutionLevel(int i) {
+        accessLevel = i;
+    }
+
+    public String getSyntax() {
+        return syntax;
+    }
+
+    public void process(StringTokenizer command, String username) {
+
+        // access level check
+        int userLevel = MWServ.getInstance().getUserLevel(username);
+        if (userLevel < getExecutionLevel()) {
+            CampaignMain.cm.toUser(
+                    "AM:Insufficient access level for command. Level: "
+                            + userLevel
+                            + ". Required: "
+                            + accessLevel
+                            + ".",
+                    username,
+                    true);
+            return;
+        }
+
+        String faction = "";
+
+        try {
+            faction = command.nextToken();
+        } catch (Exception ex) {
+            CampaignMain.cm.toUser(
+                    "Invalid syntax. Try: AdminReloadHouseConfig#faction", username, true);
+            return;
+        }
+
+        SHouse h = CampaignMain.cm.getHouseFromPartialString(faction, username);
+
+        if (h == null) {
+            return;
+        }
+
+        try {
+            h.getHouseOptions().load();
+            h.updated();
+            CampaignMain.cm.doSendModMail(
+                    "NOTE", username + " has reloaded campaign configs for " + h.getName());
+        } catch (IOException exception) {
+            LOGGER.error(
+                    "Unable to load file {}", h.getHouseOptions().getPath().toString(), exception);
+            CampaignMain.cm.toUser("Unable to load faction configs for " + h.getName(), username);
+        }
+    }
+} // end AdminReloadHouseconfigsCommand

--- a/MekWarsServer/src/mekwars/server/campaign/commands/admin/AdminSaveFactionConfigsCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/admin/AdminSaveFactionConfigsCommand.java
@@ -1,6 +1,6 @@
 /*
- * MekWars - Copyright (C) 2007 
- * 
+ * MekWars - Copyright (C) 2007
+ *
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -15,58 +15,68 @@
 
 /**
  * @author jtighe
- * 
- * Command Saves the server config to its defined file
+ *     <p>Command Saves the server config to its defined file
  */
 package mekwars.server.campaign.commands.admin;
-import mekwars.server.MWServ;
-import java.util.StringTokenizer;
-import mekwars.server.MWServ;
+
 import mekwars.server.MWChatServer.auth.IAuthenticator;
+import mekwars.server.MWServ;
 import mekwars.server.campaign.CampaignMain;
 import mekwars.server.campaign.SHouse;
 import mekwars.server.campaign.commands.Command;
 
-public class AdminSaveFactionConfigsCommand implements Command {
-	
-	int accessLevel = IAuthenticator.ADMIN;
-	String syntax = "Faction Name";
-	public int getExecutionLevel(){return accessLevel;}
-	public void setExecutionLevel(int i) {accessLevel = i;}
-	public String getSyntax() { return syntax;}
-	
-	public void process(StringTokenizer command,String Username) {
-		
-		//access level check
-		int userLevel = MWServ.getInstance().getUserLevel(Username);
-		if(userLevel < getExecutionLevel()) {
-			CampaignMain.cm.toUser("AM:Insufficient access level for command. Level: " + userLevel + ". Required: " + accessLevel + ".",Username,true);
-			return;
-		}
-		
-		String faction = "";
-        
-		try{
-		    faction = command.nextToken();
-		}
-		catch (Exception ex){
-		    CampaignMain.cm.toUser("Invalid syntax. Try: AdminSaveFactionConfigs#faction",Username,true);
-		    return;
-		}
-		
-		SHouse h = CampaignMain.cm.getHouseFromPartialString(faction,Username);
-		
-		if ( h == null )
-		    return;
+import java.util.StringTokenizer;
 
-		// Need to repopulate this in case they've changed.
-		h.populateUnitLimits();
-		h.populateBMLimits();
-		
-		h.saveConfigFile();
-		h.setUsedMekBayMultiplier(h.getFloatConfig("UsedPurchaseCostMulti"));
-		CampaignMain.cm.toUser("AM:Status saved!",Username,true);
-		CampaignMain.cm.doSendModMail("NOTE",Username + " has saved "+faction+"'s configs");
-		
-	}//end process
+public class AdminSaveFactionConfigsCommand implements Command {
+
+    int accessLevel = IAuthenticator.ADMIN;
+    String syntax = "Faction Name";
+
+    public int getExecutionLevel() {
+        return accessLevel;
+    }
+
+    public void setExecutionLevel(int i) {
+        accessLevel = i;
+    }
+
+    public String getSyntax() {
+        return syntax;
+    }
+
+    public void process(StringTokenizer command, String username) {
+
+        // access level check
+        int userLevel = MWServ.getInstance().getUserLevel(username);
+        if (userLevel < getExecutionLevel()) {
+            CampaignMain.cm.toUser(
+                    "AM:Insufficient access level for command. Level: "
+                            + userLevel
+                            + ". Required: "
+                            + accessLevel
+                            + ".",
+                    username,
+                    true);
+            return;
+        }
+
+        String faction = "";
+
+        try {
+            faction = command.nextToken();
+        } catch (Exception ex) {
+            CampaignMain.cm.toUser(
+                    "Invalid syntax. Try: AdminSaveFactionConfigs#faction", username, true);
+            return;
+        }
+
+        SHouse h = CampaignMain.cm.getHouseFromPartialString(faction, username);
+
+        if (h == null) return;
+
+        h.getHouseOptions().save();
+        h.setUsedMekBayMultiplier(h.getHouseOptions().getFloatConfig("UsedPurchaseCostMulti"));
+        CampaignMain.cm.toUser("AM:Status saved!", username, true);
+        CampaignMain.cm.doSendModMail("NOTE", username + " has saved " + faction + "'s configs");
+    } // end process
 }

--- a/MekWarsServer/src/mekwars/server/campaign/commands/admin/AdminSaveServerConfigsCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/admin/AdminSaveServerConfigsCommand.java
@@ -59,7 +59,7 @@ public class AdminSaveServerConfigsCommand implements Command {
             return;
         }
 
-        CampaignData.cd.getCampaignOptions().getDefaultOptions().createConfig(MWServ.getInstance().getConfigParam("CAMPAIGNCONFIG"));
+        CampaignData.cd.getCampaignOptions().save();
         CampaignMain.cm.toUser("AM:Status saved!", Username, true);
         CampaignMain.cm.doSendModMail("NOTE", Username + " has saved the server configs");
     } // end process

--- a/MekWarsServer/src/mekwars/server/campaign/commands/admin/CampaignConfigCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/admin/CampaignConfigCommand.java
@@ -25,7 +25,6 @@ import mekwars.server.campaign.commands.Command;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.FileInputStream;
 import java.util.StringTokenizer;
 
 public class CampaignConfigCommand implements Command {
@@ -63,12 +62,7 @@ public class CampaignConfigCommand implements Command {
         }
 
         try { // Try to read the config file
-            CampaignData.cd
-                    .getCampaignOptions()
-                    .getProperties()
-                    .load(
-                            new FileInputStream(
-                                    MWServ.getInstance().getConfigParam("CAMPAIGNCONFIG")));
+            CampaignData.cd.getCampaignOptions().load();
         } catch (Exception ex) {
             LOGGER.error("Exception: ", ex);
             CampaignMain.cm.toUser("Failed to read campaign config.", username, true);

--- a/MekWarsServer/src/mekwars/server/campaign/commands/admin/ForceUpdateCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/admin/ForceUpdateCommand.java
@@ -88,8 +88,8 @@ public class ForceUpdateCommand implements Command {
 
         if (updateKey.equalsIgnoreCase("Clear") || updateKey.equalsIgnoreCase("-1")) updateKey = "";
 
-        CampaignMain.cm.getCampaignOptions().setProperty("ForceUpdateKey", updateKey);
-        CampaignData.cd.getCampaignOptions().getDefaultOptions().createConfig(MWServ.getInstance().getConfigParam("CAMPAIGNCONFIG"));
+        CampaignData.cd.getCampaignOptions().setProperty("ForceUpdateKey", updateKey);
+        CampaignData.cd.getCampaignOptions().save();
 
         CampaignMain.cm.doSendModMail("NOTE", username + " set the Force Update Key");
         CampaignMain.cm.toUser(

--- a/MekWarsServer/src/mekwars/server/io/FileSystem.java
+++ b/MekWarsServer/src/mekwars/server/io/FileSystem.java
@@ -1,6 +1,6 @@
 /*
  * MekWars - Copyright (C) 2025
- * 
+ *
  * Derived from MegaMekNET (http://www.sourceforge.net/projects/megameknet)
  * Original author Helge Richter (McWizard)
  *
@@ -17,101 +17,100 @@
 
 package mekwars.server.io;
 
-import java.nio.file.FileSystems;
-import java.nio.file.Path;
 import mekwars.common.io.AbstractFileSystem;
 
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+
 public class FileSystem extends AbstractFileSystem {
-    protected static final Path DIRECTORY_OPERATIONS_PLANETS = FileSystems.getDefault()
-        .getPath(DIRECTORY_NAME_DATA, "planets.xml");
+    protected static final Path DIRECTORY_OPERATIONS_PLANETS =
+            FileSystems.getDefault().getPath(DIRECTORY_NAME_DATA, "planets.xml");
 
-    protected static final Path DIRECTORY_DATA_TERRAIN = FileSystems.getDefault()
-        .getPath(DIRECTORY_NAME_DATA, "terrain.xml");
+    protected static final Path DIRECTORY_DATA_TERRAIN =
+            FileSystems.getDefault().getPath(DIRECTORY_NAME_DATA, "terrain.xml");
 
-    protected static final Path DIRECTORY_DATA_ADVANCED_TERRAIN = FileSystems.getDefault()
-        .getPath(DIRECTORY_NAME_DATA, "advancedTerrain.xml");
+    protected static final Path DIRECTORY_DATA_ADVANCED_TERRAIN =
+            FileSystems.getDefault().getPath(DIRECTORY_NAME_DATA, "advancedTerrain.xml");
 
-    protected static final Path DIRECTORY_DATA_SUPPORT_UNITS = FileSystems.getDefault()
-        .getPath(DIRECTORY_NAME_DATA, "supportunits.txt");
+    protected static final Path DIRECTORY_DATA_SUPPORT_UNITS =
+            FileSystems.getDefault().getPath(DIRECTORY_NAME_DATA, "supportunits.txt");
 
     private static final String DIRECTORY_NAME_OPERATIONS = DIRECTORY_NAME_DATA + "operations/";
-    private static final Path DIRECTORY_OPERATIONS = FileSystems.getDefault()
-        .getPath(DIRECTORY_NAME_OPERATIONS);
+    private static final Path DIRECTORY_OPERATIONS =
+            FileSystems.getDefault().getPath(DIRECTORY_NAME_OPERATIONS);
 
-    protected static final String DIRECTORY_NAME_OPERATIONS_SHORT = DIRECTORY_NAME_OPERATIONS
-        + "short/";
+    protected static final String DIRECTORY_NAME_OPERATIONS_SHORT =
+            DIRECTORY_NAME_OPERATIONS + "short/";
 
-    protected static final Path DIRECTORY_OPERATIONS_SHORT = FileSystems.getDefault()
-        .getPath(DIRECTORY_NAME_OPERATIONS_SHORT);
+    protected static final Path DIRECTORY_OPERATIONS_SHORT =
+            FileSystems.getDefault().getPath(DIRECTORY_NAME_OPERATIONS_SHORT);
 
-    protected static final String DIRECTORY_NAME_OPERATIONS_LONG = DIRECTORY_NAME_OPERATIONS
-        + "long/";
+    protected static final String DIRECTORY_NAME_OPERATIONS_LONG =
+            DIRECTORY_NAME_OPERATIONS + "long/";
 
-    protected static final Path DIRECTORY_OPERATIONS_LONG = FileSystems.getDefault()
-        .getPath(DIRECTORY_NAME_OPERATIONS_LONG);
+    protected static final Path DIRECTORY_OPERATIONS_LONG =
+            FileSystems.getDefault().getPath(DIRECTORY_NAME_OPERATIONS_LONG);
 
-    protected static final String DIRECTORY_NAME_OPERATIONS_MODIFIERS = DIRECTORY_NAME_OPERATIONS
-        + "modifiers/";
+    protected static final String DIRECTORY_NAME_OPERATIONS_MODIFIERS =
+            DIRECTORY_NAME_OPERATIONS + "modifiers/";
 
-    protected static final Path DIRECTORY_OPERATIONS_MODIFIERS = FileSystems.getDefault()
-        .getPath(DIRECTORY_NAME_OPERATIONS_MODIFIERS);
+    protected static final Path DIRECTORY_OPERATIONS_MODIFIERS =
+            FileSystems.getDefault().getPath(DIRECTORY_NAME_OPERATIONS_MODIFIERS);
 
     protected static final String DIRECTORY_NAME_CAMPAIGN = "campaign/";
 
-    protected static final Path DIRECTORY_CAMPAIGN = FileSystems.getDefault()
-        .getPath(DIRECTORY_NAME_CAMPAIGN);
+    protected static final Path DIRECTORY_CAMPAIGN =
+            FileSystems.getDefault().getPath(DIRECTORY_NAME_CAMPAIGN);
 
-    protected static final Path DIRECTORY_CAMPAIGN_MECH_STAT = FileSystems.getDefault()
-        .getPath(DIRECTORY_NAME_CAMPAIGN, "mechstat.dat");
+    protected static final Path DIRECTORY_CAMPAIGN_MECH_STAT =
+            FileSystems.getDefault().getPath(DIRECTORY_NAME_CAMPAIGN, "mechstat.dat");
 
-    protected static final String DIRECTORY_NAME_CAMPAIGN_PLAYERS = DIRECTORY_NAME_CAMPAIGN
-        + "players/";
+    protected static final String DIRECTORY_NAME_CAMPAIGN_PLAYERS =
+            DIRECTORY_NAME_CAMPAIGN + "players/";
 
-    protected static final Path DIRECTORY_CAMPAIGN_PLAYERS = FileSystems.getDefault()
-        .getPath(DIRECTORY_NAME_CAMPAIGN_PLAYERS);
+    protected static final Path DIRECTORY_CAMPAIGN_PLAYERS =
+            FileSystems.getDefault().getPath(DIRECTORY_NAME_CAMPAIGN_PLAYERS);
 
-    protected static final String DIRECTORY_NAME_CAMPAIGN_PLANETS = DIRECTORY_NAME_CAMPAIGN
-        + "planets/";
+    protected static final String DIRECTORY_NAME_CAMPAIGN_PLANETS =
+            DIRECTORY_NAME_CAMPAIGN + "planets/";
 
-    protected static final Path DIRECTORY_CAMPAIGN_PLANETS = FileSystems.getDefault()
-        .getPath(DIRECTORY_NAME_CAMPAIGN_PLANETS);
+    protected static final Path DIRECTORY_CAMPAIGN_PLANETS =
+            FileSystems.getDefault().getPath(DIRECTORY_NAME_CAMPAIGN_PLANETS);
 
-    protected static final String DIRECTORY_NAME_CAMPAIGN_FACTIONS = DIRECTORY_NAME_CAMPAIGN
-        + "factions/";
+    protected static final String DIRECTORY_NAME_CAMPAIGN_FACTIONS =
+            DIRECTORY_NAME_CAMPAIGN + "factions/";
 
-    protected static final Path DIRECTORY_CAMPAIGN_FACTIONS = FileSystems.getDefault()
-        .getPath(DIRECTORY_NAME_CAMPAIGN_FACTIONS);
+    protected static final Path DIRECTORY_CAMPAIGN_FACTIONS =
+            FileSystems.getDefault().getPath(DIRECTORY_NAME_CAMPAIGN_FACTIONS);
 
-    protected static final String DIRECTORY_NAME_CAMPAIGN_COST_MODIFIERS = DIRECTORY_NAME_CAMPAIGN
-        + "costmodifiers/";
+    protected static final String DIRECTORY_NAME_CAMPAIGN_COST_MODIFIERS =
+            DIRECTORY_NAME_CAMPAIGN + "costmodifiers/";
 
-    protected static final Path DIRECTORY_CAMPAIGN_COST_MODIFIERS = FileSystems.getDefault()
-        .getPath(DIRECTORY_NAME_CAMPAIGN_COST_MODIFIERS);
+    protected static final Path DIRECTORY_CAMPAIGN_COST_MODIFIERS =
+            FileSystems.getDefault().getPath(DIRECTORY_NAME_CAMPAIGN_COST_MODIFIERS);
 
-    protected static final String DIRECTORY_NAME_CAMPAIGN_BACKUP = DIRECTORY_NAME_CAMPAIGN
-        + "backup/";
+    protected static final String DIRECTORY_NAME_CAMPAIGN_BACKUP =
+            DIRECTORY_NAME_CAMPAIGN + "backup/";
 
-    protected static final Path DIRECTORY_CAMPAIGN_BACKUP = FileSystems.getDefault()
-        .getPath(DIRECTORY_NAME_CAMPAIGN_BACKUP);
+    protected static final Path DIRECTORY_CAMPAIGN_BACKUP =
+            FileSystems.getDefault().getPath(DIRECTORY_NAME_CAMPAIGN_BACKUP);
 
-    protected Path campaignConfigPath = FileSystems.getDefault().getPath(
-            getConfigDir().toString(),
-            FILE_NAME_CAMPAIGN_CONFIG
-        );
+    protected Path campaignConfigPath =
+            FileSystems.getDefault().getPath(getConfigDir().toString(), FILE_NAME_CAMPAIGN_CONFIG);
 
-
-    private static final Path[] DIRECTORIES = new Path[] {
-        DIRECTORY_OPERATIONS,
-        DIRECTORY_OPERATIONS_SHORT,
-        DIRECTORY_OPERATIONS_LONG,
-        DIRECTORY_OPERATIONS_MODIFIERS,
-        DIRECTORY_CAMPAIGN,
-        DIRECTORY_CAMPAIGN_PLAYERS,
-        DIRECTORY_CAMPAIGN_PLANETS,
-        DIRECTORY_CAMPAIGN_FACTIONS,
-        DIRECTORY_CAMPAIGN_COST_MODIFIERS,
-        DIRECTORY_CAMPAIGN_BACKUP
-    };
+    private static final Path[] DIRECTORIES =
+            new Path[] {
+                DIRECTORY_OPERATIONS,
+                DIRECTORY_OPERATIONS_SHORT,
+                DIRECTORY_OPERATIONS_LONG,
+                DIRECTORY_OPERATIONS_MODIFIERS,
+                DIRECTORY_CAMPAIGN,
+                DIRECTORY_CAMPAIGN_PLAYERS,
+                DIRECTORY_CAMPAIGN_PLANETS,
+                DIRECTORY_CAMPAIGN_FACTIONS,
+                DIRECTORY_CAMPAIGN_COST_MODIFIERS,
+                DIRECTORY_CAMPAIGN_BACKUP
+            };
 
     private static class LazyHolder {
         private static final FileSystem INSTANCE = new FileSystem();
@@ -154,7 +153,7 @@ public class FileSystem extends AbstractFileSystem {
     }
 
     public void setCampaignConfig(String path) {
-        FileSystems.getDefault().getPath(path);
+        campaignConfigPath = FileSystems.getDefault().getPath(path);
     }
 
     @Override

--- a/MekWarsServer/src/mekwars/server/util/AutomaticBackup.java
+++ b/MekWarsServer/src/mekwars/server/util/AutomaticBackup.java
@@ -127,8 +127,7 @@ public class AutomaticBackup extends Thread {
                 .setProperty("LastAutomatedBackup", Long.toString(time));
         CampaignData.cd
                 .getCampaignOptions()
-                .getDefaultOptions()
-                .createConfig(MWServ.getInstance().getConfigParam("CAMPAIGNCONFIG"));
+                .save();
         CampaignMain.cm.setArchiving(false);
         LOGGER.info("Archiving Ended.");
     }


### PR DESCRIPTION
Turns out every house has their own configuration that has the same fields as `CampaignOptions`, however if a field is missing it defers to the `CampaignOptions`. The issue is this config lives in SHouse as a `Property` class. This prevents the client side from properly being able to use this configuration and I would also imagine this config would be rehydrated every time Hibernate creates this class when we eventually switch to SQL. 

As stated above the client technically doesn't see house configurations making it impossible to move `SHouse.getConfig` into House. Instead what happens is when you join a faction, or log in belonging to one, GetFactionConfig is called giving the faction config to the client. This new config is then put into `CampaignOptions` and overrides any existing parameters.

This PR creates the `HouseOptions` class that exists for both the client and server, with an always empty `HouseOptions` config on the client to keep in line with the above functionality and allows a followup PR to add a proper faction config for the client.