### PR TITLE
Move SPlayer and CPlayer methods into Player

### DIFF
--- a/MekWarsClient/src/mekwars/client/ClientThread.java
+++ b/MekWarsClient/src/mekwars/client/ClientThread.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Random;
 import java.util.StringTokenizer;
 import java.util.TreeSet;
@@ -29,7 +30,6 @@ import megamek.client.bot.BotClient;
 import megamek.client.bot.princess.Princess;
 import megamek.client.generator.RandomGenderGenerator;
 import megamek.client.ui.swing.ClientGUI;
-import megamek.client.ui.swing.MegaMekGUI;
 import megamek.client.ui.swing.util.MegaMekController;
 import megamek.common.Board;
 import megamek.common.BoardDimensions;
@@ -72,8 +72,8 @@ public class ClientThread extends Thread implements CloseClientListener {
     private ClientGUI swingGui;
     private MegaMekController controller;
 
-    private ArrayList<Unit> mechs = new ArrayList<Unit>();
-    private ArrayList<CUnit> autoarmy = new ArrayList<CUnit>();// from server's
+    private List<Unit> mechs = new ArrayList<Unit>();
+    private List<CUnit> autoarmy = new ArrayList<CUnit>();// from server's
     // auto army
     CArmy army = null;
     BotClient bot = null;
@@ -86,7 +86,7 @@ public class ClientThread extends Thread implements CloseClientListener {
     final int NW = 5;
 
     // CONSTRUCTOR
-    public ClientThread(String name, String servername, String ip, int port, MWClient mwclient, ArrayList<Unit> mechs, ArrayList<CUnit> autoarmy) {
+    public ClientThread(String name, String servername, String ip, int port, MWClient mwclient, List<Unit> mechs, List<CUnit> autoarmy) {
         super(name);
         myname = name.trim();
         serverName = servername;

--- a/MekWarsClient/src/mekwars/client/MWClient.java
+++ b/MekWarsClient/src/mekwars/client/MWClient.java
@@ -1001,8 +1001,8 @@ public final class MWClient extends GameHost implements IClient {
     public void startHost(boolean dedicated, boolean deploy,
             boolean loadSavegame) {
 
-        ArrayList<Unit> meks;
-        ArrayList<CUnit> autoArmy;
+        List<Unit> meks;
+        List<CUnit> autoArmy;
         
         try {
             super.startHost(dedicated, deploy, loadSavegame);
@@ -1075,8 +1075,8 @@ public final class MWClient extends GameHost implements IClient {
     }
 
     public void startClient(String hostName, boolean deploy) {
-        ArrayList<Unit> meks = new ArrayList<Unit>();
-        ArrayList<CUnit> autoArmy = new ArrayList<CUnit>();
+        List<Unit> meks = new ArrayList<Unit>();
+        List<CUnit> autoArmy = new ArrayList<CUnit>();
 
         // If a row is selected
         if ((servers.size() > 0) && (hostName != null)

--- a/MekWarsClient/src/mekwars/client/campaign/CPlayer.java
+++ b/MekWarsClient/src/mekwars/client/campaign/CPlayer.java
@@ -49,7 +49,6 @@ import org.apache.logging.log4j.Logger;
  */
 public class CPlayer extends Player<CUnit> {
     private static final Logger LOGGER = LogManager.getLogger(CPlayer.class);
-    private static final int TECH_TYPES = UnitUtils.TECH_ELITE + 1;
 
     public static final String DELIMITER = "#"; // delimiter for player strings
 
@@ -74,8 +73,6 @@ public class CPlayer extends Player<CUnit> {
     private CPersonalPilotQueues personalPilotQueue;
 
     private House houseFightingFor = null;
-    private List<Integer> totalTechs = new ArrayList<Integer>(TECH_TYPES);
-    private List<Integer> availableTechs = new ArrayList<Integer>(TECH_TYPES);
 
     private int repairLocation = 0;
     private int repairTechType = 0;
@@ -101,10 +98,6 @@ public class CPlayer extends Player<CUnit> {
         personalPilotQueue = new CPersonalPilotQueues();
         adminExcludes = new ArrayList<String>();
         playerExcludes = new ArrayList<String>();
-        for (int x = 0; x < 4; x++) {
-            availableTechs.add(0);
-            totalTechs.add(0);
-        }
     }
 
     public boolean decodeCommand(String command) {
@@ -121,11 +114,11 @@ public class CPlayer extends Player<CUnit> {
 
         if (element.equals("DA")) {// is a PI|DA
             if (!setData(command)) {
-                return (false);
+                return false;
             }
-            return (true);
+            return true;
         }
-        return (false);
+        return false;
     }
 
     /**
@@ -1068,17 +1061,6 @@ public class CPlayer extends Player<CUnit> {
         }
     }
 
-    public void setTotalTechs(int slot, int techs) {
-        if (techs < 0 || techs >= TECH_TYPES) {
-            return;
-        }
-        totalTechs.set(slot, techs);
-    }
-
-    public List<Integer> getTotalTechs() {
-        return totalTechs;
-    }
-
     public void updateAvailableTechs(String data) {
         StringTokenizer techs = new StringTokenizer(data, "%");
         int slot = 0;
@@ -1087,17 +1069,6 @@ public class CPlayer extends Player<CUnit> {
             setAvailableTechs(slot, TokenReader.readInt(techs));
             slot++;
         }
-    }
-
-    public void setAvailableTechs(int slot, int techs) {
-        if (techs < 0 || techs >= TECH_TYPES) {
-            return;
-        }
-        availableTechs.set(slot, techs);
-    }
-
-    public List<Integer> getAvailableTechs() {
-        return availableTechs;
     }
 
     public void setRepairLocation(int loc) {

--- a/MekWarsClient/src/mekwars/client/campaign/CPlayer.java
+++ b/MekWarsClient/src/mekwars/client/campaign/CPlayer.java
@@ -53,12 +53,8 @@ public class CPlayer extends Player<CUnit> {
     public static final String DELIMITER = "#"; // delimiter for player strings
 
     private MWClient mwclient;
-    private String name;
     private String House;
-    private String myLogo = "";
 
-    private int experience;
-    private int money;
     private int bays;
     private int freeBays = 0;
     private int hangarPenalty;
@@ -87,9 +83,6 @@ public class CPlayer extends Player<CUnit> {
 
     public CPlayer(MWClient client) {
         mwclient = client;
-        name = "";
-        experience = 0;
-        money = 0;
         bays = 0;
         House = "";
         armies = new ArrayList<>();
@@ -170,9 +163,9 @@ public class CPlayer extends Player<CUnit> {
         armies.clear();
         clearUnits();
 
-        name = TokenReader.readString(ST);
+        setName(TokenReader.readString(ST));
 
-        money = TokenReader.readInt(ST);
+        setMoney(TokenReader.readInt(ST));
         setExperience(TokenReader.readInt(ST));
 
         Hangarcount = TokenReader.readInt(ST);
@@ -293,14 +286,6 @@ public class CPlayer extends Player<CUnit> {
         return armies;
     }
 
-    public void setExperience(int experience) {
-        this.experience = experience;
-    }
-
-    public void setMoney(int tmoney) {
-        money = tmoney;
-    }
-
     public void setBays(int tbays) {
         bays = tbays;
     }
@@ -351,30 +336,6 @@ public class CPlayer extends Player<CUnit> {
 
     public House getHouseFightingFor() {
         return houseFightingFor;
-    }
-
-    public void setLogo(String logo) {
-        myLogo = logo;
-    }
-
-    public String getLogo() {
-        return "<img height=\"140\" width=\"130\" src =\"" + myLogo + "\">";
-    }
-
-    public String getMyLogo() {
-        return myLogo;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public int getExperience() {
-        return experience;
-    }
-
-    public int getMoney() {
-        return money;
     }
 
     public int getBays() {

--- a/MekWarsClient/src/mekwars/client/campaign/CPlayer.java
+++ b/MekWarsClient/src/mekwars/client/campaign/CPlayer.java
@@ -21,9 +21,9 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.StringTokenizer;
-import java.util.Vector;
 
 import mekwars.client.MWClient;
 import mekwars.client.GUIClient;
@@ -47,42 +47,35 @@ import org.apache.logging.log4j.Logger;
 /**
  * Class for Player object used by Client
  */
-public class CPlayer extends Player {
+public class CPlayer extends Player<CUnit> {
     private static final Logger LOGGER = LogManager.getLogger(CPlayer.class);
+    private static final int TECH_TYPES = UnitUtils.TECH_ELITE + 1;
 
     public static final String DELIMITER = "#"; // delimiter for player strings
 
     private MWClient mwclient;
-    private String Name;
+    private String name;
     private String House;
     private String myLogo = "";
 
-    private int Exp;
-    private int Money;
-    private int Bays;
-    private int FreeBays;
-    private int Influence;
-    private int Techs;
-    private int TechCost;
-    private int RewardPoints;
-    private double Rating;
+    private int experience;
+    private int money;
+    private int bays;
+    private int freeBays = 0;
     private int hangarPenalty;
     private int hangarPurchasePenalties[][] = new int[6][4];
 
-    private Vector<CUnit> Hangar;
-    private Vector<CArmy> Armies;
-    private ArrayList<CUnit> AutoArmy;
+    private List<CArmy> armies;
+    private List<CUnit> autoArmy;
 
-    private ArrayList<String> adminExcludes;
-    private ArrayList<String> playerExcludes;
+    private List<String> adminExcludes;
+    private List<String> playerExcludes;
 
     private CPersonalPilotQueues personalPilotQueue;
 
-    private House myHouse = null;
     private House houseFightingFor = null;
-
-    private ArrayList<Integer> totalTechs = new ArrayList<Integer>(4);
-    private ArrayList<Integer> availableTechs = new ArrayList<Integer>(4);
+    private List<Integer> totalTechs = new ArrayList<Integer>(TECH_TYPES);
+    private List<Integer> availableTechs = new ArrayList<Integer>(TECH_TYPES);
 
     private int repairLocation = 0;
     private int repairTechType = 0;
@@ -97,22 +90,17 @@ public class CPlayer extends Player {
 
     public CPlayer(MWClient client) {
         mwclient = client;
-        Name = "";
-        Exp = 0;
-        Money = 0;
-        Bays = 0;
-        FreeBays = 0;
-        Influence = 0;
-        Rating = 0;
+        name = "";
+        experience = 0;
+        money = 0;
+        bays = 0;
         House = "";
-        Hangar = new Vector<CUnit>(1, 1);
-        Armies = new Vector<CArmy>(1, 1);
-        AutoArmy = new ArrayList<CUnit>();
+        armies = new ArrayList<>();
+        autoArmy = new ArrayList<>();
+        setMyHouse(new House());
         personalPilotQueue = new CPersonalPilotQueues();
         adminExcludes = new ArrayList<String>();
         playerExcludes = new ArrayList<String>();
-        myHouse = new House();
-        houseFightingFor = new House();
         for (int x = 0; x < 4; x++) {
             availableTechs.add(0);
             totalTechs.add(0);
@@ -145,7 +133,6 @@ public class CPlayer extends Player {
      * army's data with new dump.
      */
     public void setArmyData(String data) {
-
         CArmy newArmy = new CArmy();
         newArmy.fromString(data, this, "%", mwclient);
 
@@ -157,10 +144,10 @@ public class CPlayer extends Player {
 
         // swap the armies
         removeArmy(newArmy.getID());
-        if (Armies.size() < newArmy.getID()) {
-            Armies.add(newArmy);
+        if (armies.size() < newArmy.getID()) {
+            armies.add(newArmy);
         } else {
-            Armies.add(newArmy.getID(), newArmy);
+            armies.add(newArmy.getID(), newArmy);
         }
     }
 
@@ -187,19 +174,20 @@ public class CPlayer extends Player {
             setAvailableTechs(x, 0);
         }
 
-        Armies.clear();
-        Hangar.clear();
+        armies.clear();
+        clearUnits();
 
-        Name = TokenReader.readString(ST);
+        name = TokenReader.readString(ST);
 
-        Money = TokenReader.readInt(ST);
-        Exp = TokenReader.readInt(ST);
+        money = TokenReader.readInt(ST);
+        setExperience(TokenReader.readInt(ST));
 
         Hangarcount = TokenReader.readInt(ST);
         for (i = 0; i < Hangarcount; i++) {
             tmek = new CUnit(mwclient);
             if (tmek.setData(TokenReader.readString(ST))) {
-                Hangar.add(tmek);
+                addUnit(tmek);
+                LOGGER.debug("Adding unit {} to hanger", tmek.checkModelName());
             }
         }
 
@@ -207,16 +195,17 @@ public class CPlayer extends Player {
         for (i = 0; i < Armiescount; i++) {
             CArmy army = new CArmy();
             army.fromString(TokenReader.readString(ST), this, "%", mwclient);
-            Armies.add(army);
+            armies.add(army);
+            LOGGER.debug("Adding army {} with {} units", army.getName(), army.getAmountOfUnits());
         }
 
-        Bays = TokenReader.readInt(ST);
-        FreeBays = TokenReader.readInt(ST);
-        Rating = Double.parseDouble(TokenReader.readString(ST));
-        Influence = TokenReader.readInt(ST);
+        bays = TokenReader.readInt(ST);
+        freeBays = TokenReader.readInt(ST);
+        setRating(Double.parseDouble(TokenReader.readString(ST)));
+        setInfluence(TokenReader.readInt(ST));
         setTechnicians(TokenReader.readInt(ST));
         doPayTechniciansMath();
-        RewardPoints = TokenReader.readInt(ST);
+        setRewardPoints(TokenReader.readInt(ST));
         String string = TokenReader.readString(ST);
         setMekToken(Integer.parseInt(string));
         House = TokenReader.readString(ST);
@@ -248,7 +237,7 @@ public class CPlayer extends Player {
         try {
             CUnit unit = new CUnit(mwclient);
             if (unit.setData(data)) {
-                Hangar.add(unit);
+                addUnit(unit);
                 sortHangar();// sort it!
             }
         } catch (Exception e) {
@@ -292,7 +281,7 @@ public class CPlayer extends Player {
      */
     public boolean removeArmy(int lanceID) {
 
-        for (Iterator<CArmy> i = Armies.iterator(); i.hasNext();) {
+        for (Iterator<CArmy> i = armies.iterator(); i.hasNext();) {
             if (i.next().getID() == lanceID) {
                 i.remove();
                 mwclient.getGUIClient().getMainFrame().updateAttackMenu();// removing an army
@@ -305,62 +294,30 @@ public class CPlayer extends Player {
     }
 
     /**
-     * Remove a unit from the player's hangar. Called from PL after receipt of a
-     * PL|RU|ID (RemoveUnit#ID) command.
-     *
-     * Note that there is NOT an analagous addUnit() method. Single additions
-     * are sent to the clients using (obtusely enough) the PL|HD (hangar data)
-     * command. See .setHangarData()'s comments, as well as those in
-     * SUnit.addUnit(), for details/explanation.
-     */
-    public boolean removeUnit(int unitID) {
-
-        for (Iterator<CUnit> i = Hangar.iterator(); i.hasNext();) {
-            if (i.next().getId() == unitID) {
-                i.remove();
-                return (true);
-            }
-        }
-        return (false);
-    }
-
-    /**
      * @return Returns the armies.
      */
-    public Vector<CArmy> getArmies() {
-        return Armies;
+    public List<CArmy> getArmies() {
+        return armies;
     }
 
-    public void setExp(int texp) {
-        Exp = texp;
+    public void setExperience(int experience) {
+        this.experience = experience;
     }
 
     public void setMoney(int tmoney) {
-        Money = tmoney;
-    }
-
-    public void setRewardPoints(int rewards) {
-        RewardPoints = rewards;
+        money = tmoney;
     }
 
     public void setBays(int tbays) {
-        Bays = tbays;
+        bays = tbays;
     }
 
-    public void setFreeBays(int tfreebays) {
-        FreeBays = tfreebays;
-    }
-
-    public void setInfluence(int tinfluence) {
-        Influence = tinfluence;
-    }
-
-    public void setRating(double trating) {
-        Rating = trating;
+    public void setFreeBays(int freeBays) {
+        this.freeBays = freeBays;
     }
 
     public void setHouse(String faction) {
-        myHouse = mwclient.getData().getHouseByName(faction);
+        setMyHouse(mwclient.getData().getHouseByName(faction));
         House = faction;
 
         /*
@@ -390,6 +347,11 @@ public class CPlayer extends Player {
         return House;
     }
 
+    public void setMyHouse(House house) {
+       House = house.getName();
+       super.setMyHouse(house);
+    }
+
     public void setHouseFightingFor(String faction) {
         houseFightingFor = mwclient.getData().getHouseByName(faction);
     }
@@ -411,57 +373,29 @@ public class CPlayer extends Player {
     }
 
     public String getName() {
-        return Name;
+        return name;
     }
 
-    public int getExp() {
-        return Exp;
-    }
-
-    public double getRating() {
-        return Rating;
-    }
-
-    public int getRewardPoints() {
-        return RewardPoints;
+    public int getExperience() {
+        return experience;
     }
 
     public int getMoney() {
-        return Money;
+        return money;
     }
 
     public int getBays() {
-        return Bays;
+        return bays;
     }
 
     public int getFreeBays() {
-        return FreeBays;
-    }
-
-    public int getInfluence() {
-        return Influence;
-    }
-
-    public int getTechs() {
-        return Techs;
+        return freeBays;
     }
 
     @Override
     public void setTechnicians(int tech) {
-        Techs = tech;
+        super.setTechnicians(tech);
         doPayTechniciansMath();
-    }
-
-    public int getTechCost() {
-        if (TechCost < 0) {
-            return 0;
-        }
-        // else
-        return TechCost + getHangarPenalty();  // If not using sliding hangar costs, hangarPenalty will be 0, so will still return the same.
-    }
-
-    public Vector<CUnit> getHangar() {
-        return Hangar;
     }
 
     /**
@@ -472,9 +406,10 @@ public class CPlayer extends Player {
     public int getNextNewArmyID() {
         int newID = -1;
         int possibleNewID = 0;
+
         while (newID == -1) {
-            for (int i = 0; i < Armies.size(); i++) {
-                if ((Armies.get(i)).getID() == possibleNewID) {
+            for (int i = 0; i < armies.size(); i++) {
+                if ((armies.get(i)).getID() == possibleNewID) {
                     newID = i;
                 }
             }
@@ -497,12 +432,11 @@ public class CPlayer extends Player {
      * locked armies.
      */
     public void setAutoArmy(StringTokenizer st) {
-
         /*
          * clear the previous autoarmy. Auto army is always called first, and is
          * cleared correctly even if only gun emplacements are sent.
          */
-        AutoArmy = new ArrayList<CUnit>();
+        autoArmy = new ArrayList<CUnit>();
 
         // if its a null, this was just a clearing call.
         if (st == null) {
@@ -549,7 +483,7 @@ public class CPlayer extends Player {
             }
 
             currUnit.setAutoUnitData(filename, distInHexes, direction);
-            AutoArmy.add(currUnit);
+            autoArmy.add(currUnit);
         }// end while(tokens)
     }// end setAutoArmy()
 
@@ -562,7 +496,6 @@ public class CPlayer extends Player {
      * locked armies.
      */
     public void setAutoGunEmplacements(StringTokenizer st) {
-
         // if its a null, this was just a clearing call.
         if (st == null) {
             return;
@@ -576,12 +509,11 @@ public class CPlayer extends Player {
 
             CUnit currUnit = new CUnit(mwclient);
             currUnit.setAutoUnitData(filename, 0, OffBoardDirection.NORTH);
-            AutoArmy.add(currUnit);
+            autoArmy.add(currUnit);
         }// end while(tokens)
     }// end setAutoArmy()
 
     public void setMULCreatedArmy(StringTokenizer st) {
-
         while (st.hasMoreElements()) {
             String data = TokenReader.readString(st);
             if (data.equalsIgnoreCase("CLEAR")) {
@@ -590,30 +522,19 @@ public class CPlayer extends Player {
 
             CUnit cm = new CUnit();
             cm.setData(data);
-            AutoArmy.add(cm);
+            autoArmy.add(cm);
         }
     }
 
     /**
      * Method which returns the autoArmy arraylist.
      */
-    public ArrayList<CUnit> getAutoArmy() {
-        return AutoArmy;
-    }
-
-    public CUnit getUnit(int unitID) {
-
-        for (CUnit currU : Hangar) {
-            if (currU.getId() == unitID) {
-                return currU;
-            }
-        }
-        return null;
+    public List<CUnit> getAutoArmy() {
+        return autoArmy;
     }
 
     public CArmy getArmy(int id) {
-
-        for (CArmy currA : Armies) {
+        for (CArmy currA : armies) {
             if (currA.getID() == id) {
                 return currA;
             }
@@ -652,7 +573,7 @@ public class CPlayer extends Player {
 
     public int getAmountOfTimesUnitExistsInArmies(int unitID) {
         int result = 0;
-        for (CArmy currA : Armies) {
+        for (CArmy currA : armies) {
             if (currA.getUnit(unitID) != null) {
                 result++;
             }
@@ -662,7 +583,7 @@ public class CPlayer extends Player {
 
     public String getArmiesUnitIsIn(int unitID) {
         StringBuilder result = new StringBuilder();
-        for (CArmy currA : Armies) {
+        for (CArmy currA : armies) {
             if (currA.getUnit(unitID) != null) {
                 result.append(currA.getID() + " ");
             }
@@ -671,9 +592,8 @@ public class CPlayer extends Player {
     }
 
     public synchronized ArrayList<Unit> getLockedUnits() {
-
         ArrayList<Unit> result = new ArrayList<Unit>();
-        for (CArmy currA : Armies) {
+        for (CArmy currA : armies) {
             if (currA.isLocked()) {
                 result.addAll(currA.getUnits());
             }
@@ -683,80 +603,12 @@ public class CPlayer extends Player {
 
     public synchronized CArmy getLockedArmy() {
 
-        for (CArmy currA : Armies) {
+        for (CArmy currA : armies) {
             if (currA.isLocked()) {
                 return currA;
             }
         }
         return null;
-    }
-
-    public void doPayTechniciansMath() {
-
-        // don't even waste time on 0 cases. Just return.
-        if (Techs <= 0) {
-            TechCost = 0;
-            return;
-        }
-
-        // starts as a double, gets cast back to an int for return.
-        float amountToPay = 0;
-
-        // load config variables needed to do the math ...
-        float additive = Float.parseFloat(mwclient.getServerConfigs("AdditivePerTech"));
-        float ceiling = Float.parseFloat(mwclient.getServerConfigs("AdditiveCostCeiling"));
-
-        /*
-         * divide the ceiling by the addiive. techs past this number are all
-         * charged at the ceiling rate. Example: (With 1.20 and .04, the result
-         * is 30. Every additional tech (31, 32, etc.) is paid at the ceiling
-         * wage.
-         */
-        int techCeiling = (int) (ceiling / additive);
-        if (Techs > techCeiling) {
-            int techsPastCeiling = Techs - techCeiling;
-            amountToPay += ceiling * techsPastCeiling;
-        }// end if(some techs are paid @ ceiling price)
-
-        /*
-         * Add up the number of times the non-ceiling techs were incremented,
-         * then figure out their total cost. In cases where the ceiling is
-         * passed, the flat fee techs are handled above, so only techs up to
-         * that ceiling need to have the additive math done. If the ceiling isnt
-         * reached, just use the number of techToPay from the param.
-         */
-        int techsUsingAdditive = 0;
-        if (Techs > techCeiling) {
-            techsUsingAdditive = techCeiling;
-        }// end if(ceiling threshold crossed)
-        else {
-            techsUsingAdditive = Techs;
-        }// end else (just using the techstopay number)
-
-        /*
-         * Faster to just to a for loop to determine the number of times the
-         * additive was made (1 + 2 + 3 + 4, and so on) with ints, and THEN
-         * multiply by the double additive than do alot of floating point math
-         * by for-in through and multiplying by the additive each time.
-         */
-        int totalAdditions = 0;
-        for (int i = 1; i <= techsUsingAdditive; i++) {
-            totalAdditions += i;
-        }// end for(all counted techs)
-
-        // now figure out the final amount to pay ...
-        amountToPay += totalAdditions * additive;
-
-        // Add penalty if the player is over a sliding limit
-
-        amountToPay += hangarPenalty;
-
-        // now return the amount in INT form since we don't support fractional
-        // MU costs.
-        // also, set the currentTechPayment, to avoid doing this math again if
-        // possible
-
-        TechCost = Math.round(amountToPay);
     }
 
     public void addArmyUnit(String data) {
@@ -845,7 +697,6 @@ public class CPlayer extends Player {
 
     public void repositionArmyUnit(String data) {
         StringTokenizer ST = new StringTokenizer(data, DELIMITER);
-
         int army = TokenReader.readInt(ST);
         int unitid = TokenReader.readInt(ST);
         int position = TokenReader.readInt(ST);
@@ -863,11 +714,11 @@ public class CPlayer extends Player {
 
         // then re-add the unit
         getArmy(army).addUnit(getUnit(unitid), position);
-
     }
 
     public void setUnitStatus(String data) {
         StringTokenizer ST = new StringTokenizer(data, DELIMITER);
+
         if (ST.hasMoreTokens()) {
             int unitid = TokenReader.readInt(ST);
             int status = TokenReader.readInt(ST);
@@ -891,7 +742,7 @@ public class CPlayer extends Player {
             int army = TokenReader.readInt(ST);
             String name = TokenReader.readString(ST);
 
-            if (name == "-1") {
+            if ("-1".equals(name)) {
                 name = "";
             }
             if (getArmy(army) != null) {
@@ -920,6 +771,7 @@ public class CPlayer extends Player {
 
     public void setArmyBV(String data) {
         StringTokenizer ST = new StringTokenizer(data, DELIMITER);
+
         if (ST.hasMoreTokens()) {
             int army = TokenReader.readInt(ST);
             if (getArmy(army) != null) {
@@ -932,6 +784,7 @@ public class CPlayer extends Player {
 
     public void setArmyLimit(String data) {
         StringTokenizer ST = new StringTokenizer(data, DELIMITER);
+
         if (ST.hasMoreTokens()) {
             int army = TokenReader.readInt(ST);
             int lowerLimit = TokenReader.readInt(ST);
@@ -944,6 +797,7 @@ public class CPlayer extends Player {
 
     public void setArmyOpForceSize(String data) {
         StringTokenizer ST = new StringTokenizer(data, DELIMITER);
+
         if (ST.hasMoreTokens()) {
             int army = TokenReader.readInt(ST);
             float opForceSize = TokenReader.readFloat(ST);
@@ -955,6 +809,7 @@ public class CPlayer extends Player {
 
     public void setArmyLock(String data) {
         StringTokenizer ST = new StringTokenizer(data, DELIMITER);
+
         if (ST.hasMoreTokens()) {
             int army = TokenReader.readInt(ST);
             boolean lock = TokenReader.readBoolean(ST);
@@ -1006,11 +861,11 @@ public class CPlayer extends Player {
         mwclient.getGUIClient().getMainFrame().getMainPanel().getUserListPanel().repaint();
     }
 
-    public ArrayList<String> getAdminExcludes() {
+    public List<String> getAdminExcludes() {
         return adminExcludes;
     }
 
-    public ArrayList<String> getPlayerExcludes() {
+    public List<String> getPlayerExcludes() {
         return playerExcludes;
     }
 
@@ -1033,7 +888,6 @@ public class CPlayer extends Player {
      * @urgru 4.4.05
      */
     public void sortHangar() {
-
         // load configs
         String primeSortOrder = mwclient.getConfigParam("PRIMARYHQSORTORDER");
         String secondarySortOrder = mwclient.getConfigParam("SECONDARYHQSORTORDER");
@@ -1068,34 +922,20 @@ public class CPlayer extends Player {
             }
         }
 
-        // we know this holds CUnits. Can safely cast.
-        Object[] unitsArray = Hangar.toArray();
-
         // run third sort
         if ((tertiarySort != primarySort) && (tertiarySort != secondarySort) && (tertiarySort != CUnitComparator.HQSORT_NONE)) {
-            Arrays.sort(unitsArray, new CUnitComparator(tertiarySort));
+            sortUnits(new CUnitComparator(tertiarySort));
         }
 
         // run the second sort
         if ((primarySort != secondarySort) && (secondarySort != CUnitComparator.HQSORT_NONE)) {
-            Arrays.sort(unitsArray, new CUnitComparator(secondarySort));
+            sortUnits(new CUnitComparator(secondarySort));
         }
 
         // now the primary sort
         if (primarySort != CUnitComparator.HQSORT_NONE) {
-            Arrays.sort(unitsArray, new CUnitComparator(primarySort));
+            sortUnits(new CUnitComparator(primarySort));
         }
-
-        // overwrite the hangar with a new arraylist constructed from the
-        // unitsArray.
-        Vector<CUnit> Hangar2 = new Vector<CUnit>(1, 1);
-        for (Object element : unitsArray) {
-            Hangar2.add((CUnit) element);
-        }
-
-        // replace the hangar and flush the array
-        Hangar = Hangar2;
-        unitsArray = null;
     }
 
     /*
@@ -1117,7 +957,6 @@ public class CPlayer extends Player {
      * @urgru 4.4.05
      */
     public void sortArmies() {
-
         // load configs
         String primeSortOrder = mwclient.getConfigParam("PRIMARYARMYSORTORDER");
         String secondarySortOrder = mwclient.getConfigParam("SECONDARYARMYSORTORDER");
@@ -1153,7 +992,7 @@ public class CPlayer extends Player {
         }
 
         // we know this holds CUnits. Can safely cast.
-        Object[] armiesArray = Armies.toArray();
+        Object[] armiesArray = armies.toArray();
 
         // run third sort
         if ((tertiarySort != primarySort) && (tertiarySort != secondarySort) && (tertiarySort != CArmyComparator.ARMYSORT_NONE)) {
@@ -1172,24 +1011,22 @@ public class CPlayer extends Player {
 
         // overwrite the hangar with a new arraylist constructed from the
         // unitsArray.
-        Vector<CArmy> Army2 = new Vector<CArmy>(1, 1);
+        ArrayList<CArmy> Army2 = new ArrayList<>();
         for (Object element : armiesArray) {
             Army2.add((CArmy) element);
         }
 
         // replace the hangar and flush the array
-        Armies = Army2;
+        armies = Army2;
         armiesArray = null;
     }
 
     public int getHangarSpaceRequired(int typeid, int weightclass, int baymod, String model) {
-
         if (typeid == Unit.PROTOMEK) {
             return 0;
         }
 
         if ((typeid == Unit.INFANTRY) && Boolean.parseBoolean(mwclient.getServerConfigs("FootInfTakeNoBays"))) {
-
             // check types
             boolean isFoot = model.startsWith("Foot");
             boolean isAMFoot = model.startsWith("Anti-Mech Foot");
@@ -1216,10 +1053,6 @@ public class CPlayer extends Player {
         return result;
     }// end getHangarSpaceRequired()
 
-    public House getMyHouse() {
-        return myHouse;
-    }
-
     public void applyUnitRepairs(StringTokenizer data) {
         CUnit unit = getUnit(TokenReader.readInt(data));
         unit.applyRepairs(TokenReader.readString(data));
@@ -1236,10 +1069,13 @@ public class CPlayer extends Player {
     }
 
     public void setTotalTechs(int slot, int techs) {
+        if (techs < 0 || techs >= TECH_TYPES) {
+            return;
+        }
         totalTechs.set(slot, techs);
     }
 
-    public ArrayList<Integer> getTotalTechs() {
+    public List<Integer> getTotalTechs() {
         return totalTechs;
     }
 
@@ -1254,11 +1090,13 @@ public class CPlayer extends Player {
     }
 
     public void setAvailableTechs(int slot, int techs) {
-
+        if (techs < 0 || techs >= TECH_TYPES) {
+            return;
+        }
         availableTechs.set(slot, techs);
     }
 
-    public ArrayList<Integer> getAvailableTechs() {
+    public List<Integer> getAvailableTechs() {
         return availableTechs;
     }
 
@@ -1326,12 +1164,15 @@ public class CPlayer extends Player {
 
             CampaignData.cd.loadHouseOptions(configPath, getMyHouse());
         }
+
         if (data.startsWith("DONE#DONE")) {
             mwclient.setWaiting(false);
             return;
         }
 
         StringTokenizer ST = new StringTokenizer(data, DELIMITER);
+        // mwclient.getServerConfigs().clear();
+        // mwclient.getServerConfigData();
         while (ST.hasMoreTokens()) {
             String key = TokenReader.readString(ST);
             String value = TokenReader.readString(ST);
@@ -1350,8 +1191,7 @@ public class CPlayer extends Player {
     }
 
     public SubFaction getSubFaction() {
-
-        SubFaction mySubFaction = myHouse.getSubFactionList().get(subFactionName);
+        SubFaction mySubFaction = getMyHouse().getSubFactionList().get(subFactionName);
         if (mySubFaction == null) {
             return new SubFaction();
         }
@@ -1360,14 +1200,12 @@ public class CPlayer extends Player {
     }
 
     public int getSubFactionAccess() {
-
-        SubFaction mySubFaction = myHouse.getSubFactionList().get(subFactionName);
+        SubFaction mySubFaction = getMyHouse().getSubFactionList().get(subFactionName);
         if (mySubFaction == null) {
             return 0;
         }
 
         return Integer.parseInt(mySubFaction.getConfig("AccessLevel"));
-
     }
 
     public String getSubFactionName() {
@@ -1399,9 +1237,5 @@ public class CPlayer extends Player {
             }
         }
         mwclient.getGUIClient().getMainFrame().getMainPanel().getHSPanel().updateDisplay();
-    }
-
-    public boolean isClan() {
-        return getMyHouse().isClan();
     }
 }

--- a/MekWarsClient/src/mekwars/client/campaign/CUnit.java
+++ b/MekWarsClient/src/mekwars/client/campaign/CUnit.java
@@ -255,7 +255,6 @@ public class CUnit extends Unit {
 
         getC3Type(unitEntity);
 
-        unitEntity.setArmor(2, 0);
         return (true);
     }
     

--- a/MekWarsClient/src/mekwars/client/campaign/CUnit.java
+++ b/MekWarsClient/src/mekwars/client/campaign/CUnit.java
@@ -255,6 +255,7 @@ public class CUnit extends Unit {
 
         getC3Type(unitEntity);
 
+        unitEntity.setArmor(2, 0);
         return (true);
     }
     

--- a/MekWarsClient/src/mekwars/client/cmd/PL.java
+++ b/MekWarsClient/src/mekwars/client/cmd/PL.java
@@ -24,6 +24,7 @@ import mekwars.client.GUIClient;
 import mekwars.client.campaign.CPlayer;
 import mekwars.client.campaign.CUnit;
 import mekwars.client.gui.dialog.AdvancedRepairDialog;
+import mekwars.common.CampaignData;
 import mekwars.common.campaign.pilot.Pilot;
 import mekwars.common.util.TokenReader;
 import mekwars.common.util.UnitUtils;
@@ -84,7 +85,7 @@ public class PL extends Command {
         } else if (cmd.equals("RU")) {
             player.removeUnit(TokenReader.readInt(st));
         } else if (cmd.equals("SE")) {
-            player.setExp(TokenReader.readInt(st));
+            player.setExperience(TokenReader.readInt(st));
         } else if (cmd.equals("SM")) {
             player.setMoney(TokenReader.readInt(st));
         } else if (cmd.equals("UMT")) {

--- a/MekWarsClient/src/mekwars/client/gui/CHQPanel.java
+++ b/MekWarsClient/src/mekwars/client/gui/CHQPanel.java
@@ -272,17 +272,17 @@ public class CHQPanel extends JPanel {
     }
 
     private void repairAllUnitsButtonActionPerformed(ActionEvent evt) {
-        if (mwclient.getPlayer().getHangar().size() > 0) {
-            new BulkRepairDialog(mwclient, mwclient.getPlayer().getHangar().firstElement().getId(), BulkRepairDialog.TYPE_BULK, BulkRepairDialog.UNIT_TYPE_ALL);
+        if (mwclient.getPlayer().getUnits().size() > 0) {
+            new BulkRepairDialog(mwclient, mwclient.getPlayer().getUnits().get(0).getId(), BulkRepairDialog.TYPE_BULK, BulkRepairDialog.UNIT_TYPE_ALL);
         }
     };
 
     private void reloadAllUnitsButtonActionPerformed(ActionEvent evt) {
-        if (mwclient.getPlayer().getHangar().size() > 0) {
+        if (mwclient.getPlayer().getUnits().size() > 0) {
             int result = JOptionPane.showConfirmDialog(mwclient.getGUIClient().getMainFrame(), "Are you sure you want to reload all the ammo on all your units?", "Reload all units?", JOptionPane.YES_NO_OPTION);
 
             if (result == JOptionPane.YES_OPTION) {
-                for (CUnit unit : mwclient.getPlayer().getHangar()) {
+                for (CUnit unit : mwclient.getPlayer().getUnits()) {
                     if (!UnitUtils.hasAllAmmo(unit.getEntity())) {
                         mwclient.sendChat(GameHost.CAMPAIGN_PREFIX + "c RELOADALLAMMO#" + unit.getId());
                     }
@@ -1189,8 +1189,8 @@ public class CHQPanel extends JPanel {
                      * CONSTRUCT the ADD menu here. It will be added to the actual format later. @urgru 12/7/04
                      */
                     JMenu addMenu = new JMenu("Add");
-                    if ((mwclient.getPlayer().getHangar().size() > 0) && !l.isLocked()) {
-                        Object[] mechArray = mwclient.getPlayer().getHangar().toArray();
+                    if ((mwclient.getPlayer().getUnits().size() > 0) && !l.isLocked()) {
+                        Object[] mechArray = mwclient.getPlayer().getUnits().toArray();
                         if (mechArray.length > 0) {
                             Vector<Vector<JMenuItem>> SubMenus = new Vector<Vector<JMenuItem>>(1, 1);
 
@@ -1420,10 +1420,10 @@ public class CHQPanel extends JPanel {
                         /*
                          * EXCHANGE. Derived from ADD. Same, but returns clicked unit to hangar.
                          */
-                        if ((mwclient.getPlayer().getHangar().size() > 0) && !l.isLocked()) {
+                        if ((mwclient.getPlayer().getUnits().size() > 0) && !l.isLocked()) {
                             JMenu jm = new JMenu("Exchange");
                             popup.add(jm);
-                            Object[] mechs = mwclient.getPlayer().getHangar().toArray();
+                            Object[] mechs = mwclient.getPlayer().getUnits().toArray();
                             if (mechs.length > 0) {
                                 Vector<Vector<JMenuItem>> SubMenus = new Vector<Vector<JMenuItem>>();
 
@@ -1998,7 +1998,7 @@ public class CHQPanel extends JPanel {
 
                     else if (Player.getFreeBays() > 0) {
                         int hangernum = (((row - MekTable.getRowsForArmies()) * (MekTable.getColumnCount() - 1)) + col) - 1;
-                        if (hangernum == mwclient.getPlayer().getHangar().size()) {// only
+                        if (hangernum == mwclient.getPlayer().getUnits().size()) {// only
                             // show
                             // in
                             // first
@@ -2892,7 +2892,7 @@ public class CHQPanel extends JPanel {
                 freebays = 0;
             }
 
-            return (int) Math.ceil((double) (freebays + Player.getHangar().size()) / (getColumnCount() - 1));
+            return (int) Math.ceil((double) (freebays + Player.getUnits().size()) / (getColumnCount() - 1));
         }
 
         public int getRowsForArmies() {
@@ -2951,8 +2951,8 @@ public class CHQPanel extends JPanel {
                     return null;
                 }
                 int hangernum = (((row - getRowsForArmies()) * (getColumnCount() - 1)) + col) - 1;
-                if ((hangernum >= 0) && (hangernum < Player.getHangar().size())) {
-                    return Player.getHangar().get(hangernum);
+                if ((hangernum >= 0) && (hangernum < Player.getUnits().size())) {
+                    return Player.getUnits().get(hangernum);
                 }
             }
             return null;
@@ -3080,7 +3080,7 @@ public class CHQPanel extends JPanel {
                 return " - ";
             } else if (cm == null) {// and in hangar row
                 int hangernum = (((row - getRowsForArmies()) * (getColumnCount() - 1)) + col) - 1;
-                if (hangernum == Player.getHangar().size()) {// only show in
+                if (hangernum == Player.getUnits().size()) {// only show in
                     // first free
                     // cell
                     if (useAdvanceRepairs) {
@@ -3327,7 +3327,7 @@ public class CHQPanel extends JPanel {
                     if (freebays < 0) {
                         freebays = 0;
                     }
-                    if (meknum > (freebays + Player.getHangar().size())) {
+                    if (meknum > (freebays + Player.getUnits().size())) {
                         c.setText("");
                     }
                 }

--- a/MekWarsClient/src/mekwars/client/gui/CMainFrame.java
+++ b/MekWarsClient/src/mekwars/client/gui/CMainFrame.java
@@ -2166,13 +2166,13 @@ public class CMainFrame extends JFrame {
         }
 
         int techs = Integer.parseInt(techsToFire);
-        if (!useAdvanceRepairs && (thePlayer.getTechs() <= 0)) {
+        if (!useAdvanceRepairs && (thePlayer.getTechnicians() <= 0)) {
             mwclient.getGUIClient().addToChat("<b>You have no hired techs to fire.<b>");
             return;
         }
 
-        if (!useAdvanceRepairs && ((techs < 1) || (techs > thePlayer.getTechs()))) {
-            mwclient.getGUIClient().addToChat("<b>Try picking a number between 1 and " + thePlayer.getTechs() + "<b>");
+        if (!useAdvanceRepairs && ((techs < 1) || (techs > thePlayer.getTechnicians()))) {
+            mwclient.getGUIClient().addToChat("<b>Try picking a number between 1 and " + thePlayer.getTechnicians() + "<b>");
             return;
         }
 

--- a/MekWarsClient/src/mekwars/client/gui/CMainFrame.java
+++ b/MekWarsClient/src/mekwars/client/gui/CMainFrame.java
@@ -1846,7 +1846,7 @@ public class CMainFrame extends JFrame {
 
     public void jMenuCommanderLogo_actionPerformed() {
         String LogoURL;
-        LogoURL = JOptionPane.showInputDialog(getContentPane(), "URL? (i.e. http://www.mysite.com/mypic.jpg)", mwclient.getPlayer().getMyLogo());
+        LogoURL = JOptionPane.showInputDialog(getContentPane(), "URL? (i.e. http://www.mysite.com/mypic.jpg)", mwclient.getPlayer().getLogo());
         if (LogoURL == null) {
             return;
         }

--- a/MekWarsClient/src/mekwars/client/gui/CPlayerPanel.java
+++ b/MekWarsClient/src/mekwars/client/gui/CPlayerPanel.java
@@ -199,7 +199,7 @@ public class CPlayerPanel extends JScrollPane {
                 lblLogo.setBackground(mwclient.getGUIClient().getMainFrame().getBackground());
                 lblLogo.getDocument().remove(0,lblLogo.getDocument().getLength());
                 ((HTMLEditorKit) lblLogo.getEditorKit()).read(
-                    new StringReader(mwclient.getPlayer().getLogo()), lblLogo.getDocument(),0);
+                    new StringReader(mwclient.getPlayer().getLogoTag()), lblLogo.getDocument(),0);
                 lblLogo.setCaretPosition(lblLogo.getDocument().getLength());
             }catch(Exception ex){
                 LOGGER.error("Exception: ", ex);

--- a/MekWarsClient/src/mekwars/client/gui/CPlayerPanel.java
+++ b/MekWarsClient/src/mekwars/client/gui/CPlayerPanel.java
@@ -225,7 +225,7 @@ public class CPlayerPanel extends JScrollPane {
             //when the client first loads it doesn't have data in the vectors.
             try{
                 lblMekbay.setText(PP_BAYS + " " + player.getFreeBays()+"/"+player.getBays()+ " (" +mwclient.moneyOrFluMessage(true,true,player.getCurrentTechPayment())+")");
-                lblTechs.setText(PP_IDLETECHS  + " " + player.getAvailableTechs().get(UnitUtils.TECH_GREEN) + "/" + player.getAvailableTechs().get(UnitUtils.TECH_REG) + "/" + player.getAvailableTechs().get(UnitUtils.TECH_VET) + "/" + player.getAvailableTechs().get(UnitUtils.TECH_ELITE));
+                lblTechs.setText(PP_IDLETECHS  + " " + player.getAvailableTech(UnitUtils.TECH_GREEN) + "/" + player.getAvailableTech(UnitUtils.TECH_REG) + "/" + player.getAvailableTech(UnitUtils.TECH_VET) + "/" + player.getAvailableTech(UnitUtils.TECH_ELITE));
             }
             catch(Exception ex){}
         }

--- a/MekWarsClient/src/mekwars/client/gui/CPlayerPanel.java
+++ b/MekWarsClient/src/mekwars/client/gui/CPlayerPanel.java
@@ -208,7 +208,7 @@ public class CPlayerPanel extends JScrollPane {
         }//lblLogo.setIcon(mwclient.getConfig().getImage("LOGO"));}
         lblName.setText(player.getName());
         lblStatus.setText(PP_STATUS + " " + mwclient.getStatus());
-        lblExp.setText(PP_EXP + " " + player.getExp());
+        lblExp.setText(PP_EXP + " " + player.getExperience());
         DecimalFormat myFormatter = new DecimalFormat("###.##");
         String ratingStr = myFormatter.format(player.getRating());
         lblRating.setText(PP_ELO + " " + ratingStr);
@@ -224,14 +224,14 @@ public class CPlayerPanel extends JScrollPane {
         if ( mwclient.isUsingAdvanceRepairs() ){
             //when the client first loads it doesn't have data in the vectors.
             try{
-                lblMekbay.setText(PP_BAYS + " " + player.getFreeBays()+"/"+player.getBays()+ " (" +mwclient.moneyOrFluMessage(true,true,player.getTechCost())+")");
+                lblMekbay.setText(PP_BAYS + " " + player.getFreeBays()+"/"+player.getBays()+ " (" +mwclient.moneyOrFluMessage(true,true,player.getCurrentTechPayment())+")");
                 lblTechs.setText(PP_IDLETECHS  + " " + player.getAvailableTechs().get(UnitUtils.TECH_GREEN) + "/" + player.getAvailableTechs().get(UnitUtils.TECH_REG) + "/" + player.getAvailableTechs().get(UnitUtils.TECH_VET) + "/" + player.getAvailableTechs().get(UnitUtils.TECH_ELITE));
             }
             catch(Exception ex){}
         }
         else{
             lblMekbay.setText(PP_TECHS + " " + player.getFreeBays() + "/" + player.getBays());
-            lblTechs.setText(PP_PAIDTECHS + " " + player.getTechs() + " (" +mwclient.moneyOrFluMessage(true,true,player.getTechCost())+")");
+            lblTechs.setText(PP_PAIDTECHS + " " + player.getTechnicians() + " (" +mwclient.moneyOrFluMessage(true,true,player.getCurrentTechPayment())+")");
         }
 
         lblRewardPoints.setText(PP_REWARD + " " + player.getRewardPoints() + "/" + mwclient.getServerConfigs("XPRewardCap"));

--- a/MekWarsClient/src/mekwars/client/gui/dialog/AdvancedRepairDialog.java
+++ b/MekWarsClient/src/mekwars/client/gui/dialog/AdvancedRepairDialog.java
@@ -1246,3 +1246,4 @@ public class AdvancedRepairDialog extends JFrame implements ActionListener, Mous
         setCost();
     }
 }// end AdvancedRepairDialog.java
+

--- a/MekWarsClient/src/mekwars/client/gui/dialog/AdvancedRepairDialog.java
+++ b/MekWarsClient/src/mekwars/client/gui/dialog/AdvancedRepairDialog.java
@@ -27,6 +27,7 @@ import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
+import java.util.Arrays;
 import java.util.Vector;
 
 import javax.swing.BoxLayout;
@@ -95,7 +96,7 @@ public class AdvancedRepairDialog extends JFrame implements ActionListener, Mous
     private int selectedSlot = -1;
     private boolean armor = false;
     private int tablocation = 0;
-    private Vector<Integer> techs = new Vector<Integer>(1, 1);
+    private int techs[] = new int[4];
     private int techType = UnitUtils.TECH_GREEN;
     private int baseLineCost = 0;
     private int techWorkMod = 0;
@@ -144,7 +145,7 @@ public class AdvancedRepairDialog extends JFrame implements ActionListener, Mous
         mwclient = c;
         year = Integer.parseInt(mwclient.getServerConfigs("CampaignYear"));
         tablocation = c.getPlayer().getRepairLocation();
-        techs.addAll(c.getPlayer().getAvailableTechs());
+        techs = Arrays.copyOf(c.getPlayer().getAvailableTechs(), UnitUtils.TECH_TYPES);
         techType = c.getPlayer().getRepairTechType();
         retries = c.getPlayer().getRepairRetries();
         this.salvage = salvage;
@@ -262,8 +263,8 @@ public class AdvancedRepairDialog extends JFrame implements ActionListener, Mous
 
             int numberOfTechs = 1;
 
-            if (techType < UnitUtils.TECH_PILOT) {
-                numberOfTechs = mwclient.getPlayer().getAvailableTechs().get(techType);
+            if (techType < UnitUtils.TECH_TYPES) {
+                numberOfTechs = mwclient.getPlayer().getAvailableTechs()[techType];
             } else if ((techType == UnitUtils.TECH_PILOT) && playerUnit.getPilotIsReparing()) {
                 numberOfTechs = 0;
             } else if (techType == UnitUtils.TECH_REWARD_POINTS) {
@@ -918,10 +919,10 @@ public class AdvancedRepairDialog extends JFrame implements ActionListener, Mous
         techPanel.removeAll();
 
         Vector<String> techString = new Vector<String>(4, 1);
-        techString.add("Green - " + techs.elementAt(UnitUtils.TECH_GREEN));
-        techString.add("Reg   - " + techs.elementAt(UnitUtils.TECH_REG));
-        techString.add("Vet   - " + techs.elementAt(UnitUtils.TECH_VET));
-        techString.add("Elite - " + techs.elementAt(UnitUtils.TECH_ELITE));
+        techString.add("Green - " + techs[UnitUtils.TECH_GREEN]);
+        techString.add("Reg   - " + techs[UnitUtils.TECH_REG]);
+        techString.add("Vet   - " + techs[UnitUtils.TECH_VET]);
+        techString.add("Elite - " + techs[UnitUtils.TECH_ELITE]);
 
         Pilot pilot = playerUnit.getPilot();
 

--- a/MekWarsClient/src/mekwars/client/gui/dialog/BulkRepairDialog.java
+++ b/MekWarsClient/src/mekwars/client/gui/dialog/BulkRepairDialog.java
@@ -221,7 +221,7 @@ public class BulkRepairDialog extends JFrame implements ActionListener, KeyListe
                     sb.append("#" + ((JSpinner) rollBox.getComponent(type)).getValue().toString());
                 }
                 if (unitRepairType == BulkRepairDialog.UNIT_TYPE_ALL) {
-                    for (CUnit repairUnit : mwclient.getPlayer().getHangar()) {
+                    for (CUnit repairUnit : mwclient.getPlayer().getUnits()) {
                         if (((repairUnit.getType() == Unit.MEK) || (repairUnit.getType() == Unit.VEHICLE)) && (UnitUtils.hasArmorDamage(unit) || UnitUtils.hasCriticalDamage(unit) || UnitUtils.hasISDamage(unit))) {
                             mwclient.sendChat(GameHost.CAMPAIGN_PREFIX + "c simplerepair#" + repairUnit.getId() + sb.toString());
                         }
@@ -240,7 +240,7 @@ public class BulkRepairDialog extends JFrame implements ActionListener, KeyListe
             } else {
 
                 if (unitRepairType == BulkRepairDialog.UNIT_TYPE_ALL) {
-                    for (CUnit repairUnit : mwclient.getPlayer().getHangar()) {
+                    for (CUnit repairUnit : mwclient.getPlayer().getUnits()) {
                         unit = repairUnit.getEntity();
 
                         if (((repairUnit.getType() == Unit.MEK) || (repairUnit.getType() == Unit.VEHICLE)) && (UnitUtils.hasArmorDamage(unit) || UnitUtils.hasCriticalDamage(unit) || UnitUtils.hasISDamage(unit)) ){

--- a/MekWarsClient/src/mekwars/client/gui/dialog/RewardPointsDialog.java
+++ b/MekWarsClient/src/mekwars/client/gui/dialog/RewardPointsDialog.java
@@ -170,7 +170,7 @@ public final class RewardPointsDialog implements ActionListener, KeyListener{
 
             repodComboBox = new JComboBox(repodOptions.toArray());
             repodOptions.clear();
-            Iterator<CUnit> units = c.getPlayer().getHangar().iterator();
+            Iterator<CUnit> units = c.getPlayer().getUnits().iterator();
             while (units.hasNext()){
                 CUnit unit = units.next();
                 if ( !unit.isOmni() )
@@ -182,7 +182,7 @@ public final class RewardPointsDialog implements ActionListener, KeyListener{
         if (Boolean.parseBoolean(mwclient.getServerConfigs("AllowRepairsForRewards"))){
             names.add(repairCommand);
             TreeSet<String> damagedUnits = new TreeSet<String>();
-            for ( CUnit unit: mwclient.getPlayer().getHangar() ){
+            for ( CUnit unit: mwclient.getPlayer().getUnits() ){
                 if ( UnitUtils.hasArmorDamage(unit.getEntity()) || UnitUtils.hasCriticalDamage(unit.getEntity()) )
                     damagedUnits.add("#"+unit.getId()+" "+unit.getModelName());
             }

--- a/MekWarsClient/src/mekwars/client/gui/dialog/SellUnitDialog.java
+++ b/MekWarsClient/src/mekwars/client/gui/dialog/SellUnitDialog.java
@@ -89,9 +89,9 @@ public class SellUnitDialog extends JDialog implements ActionListener {
         if (toSell == null || toSell.size() == 0) {
             
             toSell = new Vector<CUnit>(1,1);
-            for(CUnit currU : mwclient.getPlayer().getHangar()) {
-                if (UnitUtils.mayBeSoldOnMarket(currU)) {
-                    toSell.add(currU);
+            for(CUnit unit : mwclient.getPlayer().getUnits()) {
+                if (UnitUtils.mayBeSoldOnMarket(unit)) {
+                    toSell.add(unit);
                 }
             }
         }

--- a/MekWarsClient/src/mekwars/client/gui/dialog/UnitSelectionDialog.java
+++ b/MekWarsClient/src/mekwars/client/gui/dialog/UnitSelectionDialog.java
@@ -84,7 +84,7 @@ public class UnitSelectionDialog extends JDialog implements ActionListener {
 		comboLabel.setAlignmentY(Component.CENTER_ALIGNMENT);
 		
 		//populate the combo box
-		possibleUnits.setModel(new DefaultComboBoxModel(mwclient.getPlayer().getHangar()) {
+		possibleUnits.setModel(new DefaultComboBoxModel(mwclient.getPlayer().getUnits().toArray()) {
 			/**
              * 
              */

--- a/MekWarsClient/src/mekwars/client/protocol/DataFetchClient.java
+++ b/MekWarsClient/src/mekwars/client/protocol/DataFetchClient.java
@@ -351,7 +351,7 @@ public class DataFetchClient {
         BinReader binreader = openConnection("ServerVersion");
         Version serverVersion = new Version(binreader.readLine("ServerVersion"));
 
-        LOGGER.error("Client Version: {} Server Version: {}", clientVersion, serverVersion);
+        LOGGER.info("Client Version: {} Server Version: {}", clientVersion, serverVersion);
         mustUpdate = !serverVersion.is(clientVersion);
 
         // If the versions dont match then the client has to update anyways

--- a/MekWarsClient/src/mekwars/client/util/CUnitComparator.java
+++ b/MekWarsClient/src/mekwars/client/util/CUnitComparator.java
@@ -21,7 +21,6 @@
 import mekwars.client.campaign.CUnit;
 
  public class CUnitComparator implements Comparator<Object> {
-
  	//NOTE: This order must match order of
  	//sort options in CPLayer.sortHangar()'s
  	//"choices" array.
@@ -43,13 +42,12 @@ import mekwars.client.campaign.CUnit;
  		this.sortOrder = sortOrder;
  	}
  	
+    @Override
  	public int compare(Object obj1, Object obj2) {
- 		
  		CUnit unit1 = (CUnit)obj1;
  		CUnit unit2 = (CUnit)obj2;
  		
  		switch (sortOrder) {
- 		
  			case HQSORT_NAME : //the name
 				return unit1.getUnitFilename().compareTo(unit2.getUnitFilename());
  		
@@ -102,5 +100,4 @@ import mekwars.client.campaign.CUnit;
  				return 0;
  		}//end switch
  	}//end compare()
-
 }

--- a/MekWarsClient/src/mekwars/client/util/RepairManagmentThread.java
+++ b/MekWarsClient/src/mekwars/client/util/RepairManagmentThread.java
@@ -157,13 +157,13 @@ public class RepairManagmentThread extends Thread{
                     continue;
                 
                 //No techs for this type what so ever! buy more!
-                if ( pos != UnitUtils.TECH_PILOT && client.getPlayer().getTotalTechs().get(pos) <= 0 ){
+                if ( pos != UnitUtils.TECH_PILOT && client.getPlayer().getTotalTech(pos) <= 0 ){
                     client.systemMessage("You have pending work orders for "+UnitUtils.techDescription(pos)+" techs, but have none on your pay roll.");
                     continue;
                 }
     
                 if ( pos != UnitUtils.TECH_PILOT )
-                    availableTechs = client.getPlayer().getAvailableTechs().get(pos);
+                    availableTechs = client.getPlayer().getAvailableTech(pos);
                 
                 //all techs are busy keep it moving.
                 if ( availableTechs <= 0 ){

--- a/MekWarsClient/src/mekwars/client/util/SalvageManagmentThread.java
+++ b/MekWarsClient/src/mekwars/client/util/SalvageManagmentThread.java
@@ -152,13 +152,13 @@ public class SalvageManagmentThread extends Thread{
                     continue;
                 
                 //No techs for this type what so ever! buy more!
-                if ( pos != UnitUtils.TECH_PILOT && client.getPlayer().getTotalTechs().get(pos) <= 0 ){
+                if ( pos != UnitUtils.TECH_PILOT && client.getPlayer().getTotalTech(pos) <= 0 ){
                     client.systemMessage("You have pending work orders for "+UnitUtils.techDescription(pos)+" techs, but have none on your pay roll.");
                     continue;
                 }
     
                 if ( pos != UnitUtils.TECH_PILOT )
-                    availableTechs = client.getPlayer().getAvailableTechs().get(pos);
+                    availableTechs = client.getPlayer().getAvailableTech(pos);
                 
                 //all techs are busy keep it moving.
                 if ( availableTechs <= 0 ){

--- a/MekWarsCommon/src/mekwars/common/House.java
+++ b/MekWarsCommon/src/mekwars/common/House.java
@@ -28,17 +28,20 @@ import mekwars.common.util.HTMLConverter;
 import mekwars.common.universe.FactionTag;
 import java.io.IOException;
 import java.util.EnumSet;
-import java.util.Hashtable;
 import java.util.Set;
 import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
 import megamek.common.TechConstants;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * @author Helge Richter
  * 
  */
 public class House implements Entity {
+    private static final Logger LOGGER = LogManager.getLogger(House.class);
+    
     public static final int RED_VALUE = 0;
     public static final int GREEN_VALUE = 1;
     public static final int BLUE_VALUE = 2;
@@ -69,11 +72,8 @@ public class House implements Entity {
     private boolean allowDefectionsTo = true;
 
     private ConcurrentHashMap<String, SubFaction> subFactionList = new ConcurrentHashMap<String, SubFaction>();
-
-    public float usedMekBayMultiplier;
-
     public ConcurrentHashMap<String, Integer> supportedUnits = new ConcurrentHashMap<String, Integer>();
-
+    public float usedMekBayMultiplier;
     private boolean nonFactionUnitsCostMore = false;
     // NOTE: Once MekWars uses MegaMek version 50.04 this should use megamek.common.universe.FactionTag.
     private Set<FactionTag> tags = EnumSet.noneOf(FactionTag.class);

--- a/MekWarsCommon/src/mekwars/common/Player.java
+++ b/MekWarsCommon/src/mekwars/common/Player.java
@@ -22,11 +22,13 @@
 package mekwars.common;
 
 import mekwars.common.flags.PlayerFlags;
+import mekwars.common.util.UnitUtils;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -38,7 +40,8 @@ public class Player<T extends Unit> {
 
     private List<T> units = new ArrayList<>();
     private House myHouse = null;
-    private int influence = 0; //@salient - changed from 50 to 0, starting flu can be set in SO faction.
+    // @salient - changed from 50 to 0, starting flu can be set in SO faction.
+    private int influence = 0;
     private int technicians = 0; // @urgru 7/17/04
     private int currentTechPayment = -1; // num Cbills owed to techs after games
     private int teamNumber = -1;
@@ -46,12 +49,19 @@ public class Player<T extends Unit> {
     private double rating = INITIAL_RATING;
     private boolean isInvisible = false; // Evil command for Big brother err admins.
     private boolean autoReorderParts = false;
+    protected int totalTechs[] = new int[UnitUtils.TECH_TYPES];
+    protected int availableTechs[] = new int[UnitUtils.TECH_TYPES];
     protected PlayerFlags flags = new PlayerFlags();
     // This is only going to be set for staff
     protected PlayerFlags defaultPlayerFlags = new PlayerFlags();
     // A counter for how many meks a player is allowed to create in freebuild
     protected int mekToken = 0;
     protected int bvTracker = 0; // used to track hangar BV in mini campaigns
+
+    public Player() {
+        Arrays.fill(totalTechs, 0);
+        Arrays.fill(availableTechs, 0);
+    }
 
     public void setMyHouse(House house) {
         this.myHouse = house;
@@ -72,6 +82,36 @@ public class Player<T extends Unit> {
             }
         }
         return null;
+    }
+
+    public void setTotalTechs(int slot, int techs) {
+        if (slot < 0 || slot >= UnitUtils.TECH_TYPES) {
+            return;
+        }
+        totalTechs[slot] = techs;
+    }
+
+    public void setAvailableTechs(int slot, int techs) {
+        if (slot < 0 || slot >= UnitUtils.TECH_TYPES) {
+            return;
+        }
+        availableTechs[slot] = techs;
+    }
+
+    public int getTotalTech(int slot) {
+        return totalTechs[slot];
+    }
+
+    public int[] getTotalTechs() {
+        return totalTechs;
+    }
+
+    public int getAvailableTech(int slot) {
+        return availableTechs[slot];
+    }
+
+    public int[] getAvailableTechs() {
+        return availableTechs;
     }
 
     public List<T> getUnits() {
@@ -117,20 +157,20 @@ public class Player<T extends Unit> {
     }
 
     public void setInfluence(int influence) {
-        int influenceCeiling = CampaignData.cd.getCampaignOptions().getIntegerConfig("InfluenceCeiling");
+        int influenceCeiling =
+                CampaignData.cd.getCampaignOptions().getIntegerConfig("InfluenceCeiling");
 
         if (influenceCeiling != -1) {
             this.influence = Math.max(0, Math.min(influenceCeiling, influence));
         } else {
-            this.influence = Math.max(0,  influence);
+            this.influence = Math.max(0, influence);
         }
     }
 
     /**
      * A method to add a specified amount of influence
      *
-     * @param i
-     *            - amount of influence to add
+     * @param i - amount of influence to add
      */
     public void addInfluence(int influence) {
         setInfluence(getInfluence() + influence);
@@ -208,7 +248,6 @@ public class Player<T extends Unit> {
     public void addTechnicians(int technicians) {
         this.setTechnicians(this.technicians + technicians);
     }
-
 
     public double getRating() {
         return rating;
@@ -467,7 +506,7 @@ public class Player<T extends Unit> {
         if (additive <= 0) {
             LOGGER.error(
                     "Unable to calculate technicians pay, AdditivePerTech must be above 0, but is"
-                        + " {}",
+                            + " {}",
                     additive);
             setCurrentTechPayment(0);
             return;
@@ -476,7 +515,7 @@ public class Player<T extends Unit> {
         if (ceiling <= 0) {
             LOGGER.error(
                     "Unable to calculate technicians pay, AdditiveCostCeiling must be above 0, but"
-                        + " is {}",
+                            + " is {}",
                     ceiling);
             setCurrentTechPayment(0);
             return;

--- a/MekWarsCommon/src/mekwars/common/Player.java
+++ b/MekWarsCommon/src/mekwars/common/Player.java
@@ -1,6 +1,6 @@
 /*
- * MekWars - Copyright (C) 2004 
- * 
+ * MekWars - Copyright (C) 2004
+ *
  * Derived from MegaMekNET (http://www.sourceforge.net/projects/megameknet)
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -23,19 +23,119 @@ package mekwars.common;
 
 import mekwars.common.flags.PlayerFlags;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-public class Player {
-    
-    private int technicians = 0; //@urgru 7/17/04
-    private int currentTechPayment = -1; //num Cbills owed to techs after games
-    private boolean isInvisible = false; //Evil command for Big brother err admins.
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+
+public class Player<T extends Unit> {
+    private static final Logger LOGGER = LogManager.getLogger(Player.class);
+    private static final double INITIAL_RATING = 1600;
+
+    private List<T> units = new ArrayList<>();
+    private House myHouse = null;
+    private int influence = 0; //@salient - changed from 50 to 0, starting flu can be set in SO faction.
+    private int technicians = 0; // @urgru 7/17/04
+    private int currentTechPayment = -1; // num Cbills owed to techs after games
     private int teamNumber = -1;
+    private int rewardPoints = 0;
+    private double rating = INITIAL_RATING;
+    private boolean isInvisible = false; // Evil command for Big brother err admins.
     private boolean autoReorderParts = false;
     protected PlayerFlags flags = new PlayerFlags();
-    protected PlayerFlags defaultPlayerFlags = new PlayerFlags(); // This is only going to be set for staff
-    protected int mekToken = 0; // A counter for how many meks a player is allowed to create in freebuild
+    // This is only going to be set for staff
+    protected PlayerFlags defaultPlayerFlags = new PlayerFlags();
+    // A counter for how many meks a player is allowed to create in freebuild
+    protected int mekToken = 0;
     protected int bvTracker = 0; // used to track hangar BV in mini campaigns
-    
+
+    public void setMyHouse(House house) {
+        this.myHouse = house;
+    }
+
+    public House getMyHouse() {
+        return myHouse;
+    }
+
+    public boolean isClan() {
+        return getMyHouse().isClan();
+    }
+
+    public T getUnit(int unitId) {
+        for (T currU : units) {
+            if (currU.getId() == unitId) {
+                return currU;
+            }
+        }
+        return null;
+    }
+
+    public List<T> getUnits() {
+        return Collections.unmodifiableList(units);
+    }
+
+    public void sortUnits(Comparator<? super T> comparator) {
+        Collections.sort(units, comparator);
+    }
+
+    // @salient
+    public int getUnitCount() {
+        return units.size();
+    }
+
+    public int getRewardPoints() {
+        return rewardPoints;
+    }
+
+    public void setRewardPoints(int rewardPoints) {
+        int xpRewardCap = CampaignData.cd.getCampaignOptions().getIntegerConfig("XPRewardCap");
+
+        if (xpRewardCap != -1) {
+            rewardPoints = Math.max(0, Math.min(xpRewardCap, rewardPoints));
+        } else {
+            rewardPoints = Math.max(0, rewardPoints);
+        }
+
+        this.rewardPoints = rewardPoints;
+    }
+
+    public void addRewardPoints(int toAdd) {
+        setRewardPoints(getRewardPoints() + toAdd);
+    }
+
+    /**
+     * A method which returns a players influence
+     *
+     * @return int - influence amount
+     */
+    public int getInfluence() {
+        return influence;
+    }
+
+    public void setInfluence(int influence) {
+        int influenceCeiling = CampaignData.cd.getCampaignOptions().getIntegerConfig("InfluenceCeiling");
+
+        if (influenceCeiling != -1) {
+            this.influence = Math.max(0, Math.min(influenceCeiling, influence));
+        } else {
+            this.influence = Math.max(0,  influence);
+        }
+    }
+
+    /**
+     * A method to add a specified amount of influence
+     *
+     * @param i
+     *            - amount of influence to add
+     */
+    public void addInfluence(int influence) {
+        setInfluence(getInfluence() + influence);
+    }
+
     /**
      * @return bvTracker value
      */
@@ -49,7 +149,7 @@ public class Player {
     public void setBVTracker(int bvtracker) {
         bvTracker = bvtracker;
     }
-    
+
     /**
      * @return the mekToken
      */
@@ -70,132 +170,152 @@ public class Player {
     public int getCurrentTechPayment() {
         return currentTechPayment;
     }
-    
+
     /**
      * @param i post-task payment to set, in Cbills
      */
-    public void setCurrentTechPayment(int i) {
-        currentTechPayment = i;
+    public void setCurrentTechPayment(int techPayment) {
+        currentTechPayment = techPayment;
     }
-      
+
     /**
      * @return the number of technicians the player has
      */
     public int getTechnicians() {
         return technicians;
-    }//end getTechnicians()
-     
+    } // end getTechnicians()
+
     /**
      * @param int to set technicians to.
      */
-    public void setTechnicians(int t) {
+    public void setTechnicians(int technicians) {
+        int maxTechs = CampaignData.cd.getCampaignOptions().getIntegerConfig("MaxTechsToHire");
 
-        if (t < 0)//dont allow negative techs. always set negatives back to 0.
-            t = 0;
-        technicians = t;
-        
-        //clear the tech payment any time a new number of techs is set
+        if (maxTechs != -1) {
+            this.technicians = Math.max(0, Math.min(maxTechs, technicians));
+        } else {
+            this.technicians = Math.max(0, technicians);
+        }
+
+        // clear the tech payment any time a new number of techs is set
         currentTechPayment = -1;
-    }//end setTechnicians()
-      
+    }
+
     /**
      * @param the number of technicians to add (subtract) from the player's total
-     * 
-     * NOTE: sub-zero cases are checked in setTechs(). no check here.
+     *     <p>NOTE: sub-zero cases are checked in setTechs(). no check here.
      */
-    public void addTechnicians(int t) {
-        this.setTechnicians(technicians + t);
+    public void addTechnicians(int technicians) {
+        this.setTechnicians(this.technicians + technicians);
     }
-    
+
+
+    public double getRating() {
+        return rating;
+    }
+
+    public void setRating(double rating) {
+        this.rating = rating;
+    }
+
     /**
-     * Sets that a player now has the invis flag. 
-     * of course players with access levels >= this player
-     * will still beable to see them.
+     * Sets that a player now has the invis flag. of course players with access levels >= this
+     * player will still beable to see them.
+     *
      * @param invis
      */
-    public void setInvisible(boolean invis){
+    public void setInvisible(boolean invis) {
         isInvisible = invis;
     }
-    
+
     /**
-     * does the player have the invisible flag.
+     * Does the player have the invisible flag.
+     *
      * @return true/false.
      */
-    public boolean isInvisible(){
+    public boolean isInvisible() {
         return isInvisible;
     }
 
     /**
      * Returns players team number
+     *
      * @return
      */
     public int getTeamNumber() {
         return teamNumber;
     }
-    
+
     /**
      * Set Players team number for the current op.
+     *
      * @param team
      */
     public void setTeamNumber(int team) {
         this.teamNumber = team;
     }
-    
+
     /**
      * Sets if the player wants to reorder parts.
+     *
      * @param reorder
      */
-    public void setAutoReorder(boolean reorder){
+    public void setAutoReorder(boolean reorder) {
         this.autoReorderParts = reorder;
     }
-    
+
     /**
      * Returns if the player has auto reorder parts turned on.
+     *
      * @return
      */
-    public boolean getAutoReorder(){
+    public boolean getAutoReorder() {
         return this.autoReorderParts;
     }
-    
+
     /**
      * Sets a player flag
+     *
      * @param name - the name of the flag to set
      * @param value - true or false (String value)
      */
     public void setFlagStatus(String name, String value) {
         setFlagStatus(name, Boolean.parseBoolean(value));
     }
-    
+
     /**
      * Sets a player flag
+     *
      * @param name - the name of the flag to set
      * @param value - true or false (boolean value)
      */
     public void setFlagStatus(String name, boolean value) {
         flags.setFlag(name, value);
     }
-    
-    /** Returns the value of a flag
-     * 
+
+    /**
+     * Returns the value of a flag
+     *
      * @param name - the name of the flag to get
      * @return true or false (boolean value)
      */
     public boolean getFlagStatus(String name) {
         return flags.getFlagStatus(name);
     }
-    
+
     /**
-     * Loads the set of server-defined players flags from a string.
-     * This should probably only be called during player logon, and then
-     * each flag can be set individually
+     * Loads the set of server-defined players flags from a string. This should probably only be
+     * called during player logon, and then each flag can be set individually
+     *
      * @param data
      */
-    public void loadFlags (String data) {
+    public void loadFlags(String data) {
         flags.loadDefaults(data);
     }
-    
+
     /**
      * Exports the string of flags read by loadFlags
+     *
      * @return flag data
      */
     public String exportFlags() {
@@ -208,11 +328,223 @@ public class Player {
     public PlayerFlags getDefaultPlayerFlags() {
         return defaultPlayerFlags;
     }
-    
+
     /**
      * @return the playerFlags
      */
     public PlayerFlags getFlags() {
         return flags;
     }
-}//End Class Player
+
+    /**
+     * A method to count the units of a given type and weight in a player's hangar
+     *
+     * @param uType
+     * @param uWeightClass
+     * @return number of units
+     */
+    public int countUnits(int uType, int uWeightClass) {
+        if ((uType < 0) || (uType > Unit.AERO)) {
+            LOGGER.error("Invalid uType {}", uType);
+            return 0;
+        }
+        if ((uWeightClass < 0) || (uWeightClass > Unit.ASSAULT)) {
+            LOGGER.error("Invalid uWeightClass {}", uWeightClass);
+            return 0;
+        }
+        // Actually count them now
+        int count = 0;
+        for (Unit u : units) {
+            if (!u.isChristmasUnit()
+                    && (u.getType() == uType)
+                    && (u.getWeightclass() == uWeightClass)) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /**
+     * A method to determine if the player is over the unit limit and the server is configured to
+     * use sliding hangar cost increases
+     */
+    public boolean hasHangarPenalty(int uType, int uWeight) {
+        // Always false if we're not using the sliding limits
+        if (!getMyHouse().getHouseOptions().getBooleanConfig("UseSlidingHangarLimits")) {
+            return false;
+        }
+
+        int limit = getMyHouse().getHouseOptions().getUnitLimit(uType, uWeight);
+
+        // Always false if the particular limit is not checked
+        if (limit < 0) {
+            return false;
+        }
+
+        int numUnits = countUnits(uType, uWeight);
+        // False if we're below the limit
+        return limit < numUnits;
+    }
+
+    public int calculateHangarPenalty(int typeId, int weightclass) {
+        if (!hasHangarPenalty(typeId, weightclass)) {
+            return 0;
+        }
+
+        int penalty = 0;
+        int limit = getMyHouse().getHouseOptions().getUnitLimit(typeId, weightclass);
+        int numUnits = countUnits(typeId, weightclass);
+
+        if (numUnits <= limit) {
+            return 0;
+        }
+
+        int penaltyUnits = numUnits - limit;
+        double slidingHangerLimitModifier =
+                getMyHouse().getHouseOptions().getDoubleConfig("SlidingHangarLimitModifier");
+
+        penalty = (int) Math.pow(penaltyUnits, slidingHangerLimitModifier);
+
+        return penalty;
+    }
+
+    public int calculateTotalHangarPenalty() {
+        int penalty = 0;
+
+        for (int type = Unit.MEK; type < Unit.MAXBUILD; type++) {
+            for (int weight = Unit.LIGHT; weight <= Unit.ASSAULT; weight++) {
+                penalty += calculateHangarPenalty(type, weight);
+            }
+        }
+        return penalty;
+    }
+
+    /**
+     * Remove a unit from the player's hangar. Called from PL after receipt of a PL|RU|ID
+     * (RemoveUnit#ID) command.
+     *
+     * <p>Note that there is NOT an analagous addUnit() method. Single additions are sent to the
+     * clients using (obtusely enough) the PL|HD (hangar data) command. See .setHangarData()'s
+     * comments, as well as those in SUnit.addUnit(), for details/explanation.
+     */
+    public boolean removeUnit(int unitID) {
+        for (Iterator<T> i = units.iterator(); i.hasNext(); ) {
+            if (i.next().getId() == unitID) {
+                i.remove();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * This method does all the math to figure out how much the retainer fee, maintenance cost,
+     * whathaveyou is for the current number of technicians. The number itself is useful in some
+     * cases (let people know what they will have to pay after hiring a new tech, for example), and
+     * thus separated from the actual payment. For now, we have only one payment calculation
+     * mechanism -- additive costing, whereby each tech costs as much as the last, plus a constant
+     * kicker. A cap to this cost can be configured; however, it must be a multiple of the per-tech
+     * additive (eg, if the additive is .04, 1.20 would be a valid cap, but 1.30 wouldn't).
+     *
+     * @urgru 7/26/04
+     */
+    protected void doPayTechniciansMath() {
+        int techs = getTechnicians();
+
+        // don't even waste time on 0 cases. Just return.
+        if (techs <= 0) {
+            setCurrentTechPayment(0);
+            return;
+        }
+
+        // starts as a double, gets cast back to an int for return.
+        float amountToPay = 0;
+
+        // load config variables needed to do the math ...
+        float additive = getMyHouse().getHouseOptions().getFloatConfig("AdditivePerTech");
+        float ceiling = getMyHouse().getHouseOptions().getFloatConfig("AdditiveCostCeiling");
+
+        if (additive <= 0) {
+            LOGGER.error(
+                    "Unable to calculate technicians pay, AdditivePerTech must be above 0, but is"
+                        + " {}",
+                    additive);
+            setCurrentTechPayment(0);
+            return;
+        }
+
+        if (ceiling <= 0) {
+            LOGGER.error(
+                    "Unable to calculate technicians pay, AdditiveCostCeiling must be above 0, but"
+                        + " is {}",
+                    ceiling);
+            setCurrentTechPayment(0);
+            return;
+        }
+
+        /*
+         * divide the ceiling by the addiive. techs past this number are all
+         * charged at the ceiling rate. Example: (With 1.20 and .04, the result
+         * is 30. Every additional tech (31, 32, etc.) is paid at the ceiling
+         * wage.
+         */
+        int techCeiling = (int) (ceiling / additive);
+        if (techs > techCeiling) {
+            int techsPastCeiling = techs - techCeiling;
+            amountToPay += ceiling * techsPastCeiling;
+        } // end if(some techs are paid @ ceiling price)
+
+        /*
+         * Add up the number of times the non-ceiling techs were incremented,
+         * then figure out their total cost. In cases where the ceiling is
+         * passed, the flat fee techs are handled above, so only techs up to
+         * that ceiling need to have the additive math done. If the ceiling isnt
+         * reached, just use the number of techToPay from the param.
+         */
+        int techsUsingAdditive = 0;
+        if (techs > techCeiling) {
+            techsUsingAdditive = techCeiling;
+        } else {
+            techsUsingAdditive = techs;
+        }
+
+        /*
+         * Faster to just to a for loop to determine the number of times the
+         * additive was made (1 + 2 + 3 + 4, and so on) with ints, and THEN
+         * multiply by the double additive than do alot of floating point math
+         * by for-in through and multiplying by the additive each time.
+         */
+        int totalAdditions = 0;
+        for (int i = 1; i <= techsUsingAdditive; i++) {
+            totalAdditions += i;
+        }
+
+        // now figure out the final amount to pay ...
+        amountToPay += totalAdditions * additive;
+
+        // Add penalty if the player is over a sliding limit
+
+        for (int typeId = Unit.MEK; typeId < Unit.MAXBUILD; typeId++) {
+            for (int weightclass = Unit.LIGHT; weightclass <= Unit.ASSAULT; weightclass++) {
+                if (hasHangarPenalty(typeId, weightclass)) {
+                    int costPenalty = calculateHangarPenalty(typeId, weightclass);
+                    amountToPay += costPenalty;
+                }
+            }
+        }
+        /*
+         * now return the amount in INT form since we don't support fractional
+         * money. also, set the currentTechPayment, to avoid doing this math
+         * again if possible.
+         */
+        setCurrentTechPayment(Math.max(0, Math.round(amountToPay)));
+    }
+
+    protected void clearUnits() {
+        units.clear();
+    }
+
+    protected void addUnit(T unit) {
+        units.add(unit);
+    }
+}

--- a/MekWarsCommon/src/mekwars/common/Player.java
+++ b/MekWarsCommon/src/mekwars/common/Player.java
@@ -39,13 +39,18 @@ public class Player<T extends Unit> {
     private static final double INITIAL_RATING = 1600;
 
     private List<T> units = new ArrayList<>();
+    private String name = "";
+    private String logo = "";
     private House myHouse = null;
+    private int money = 0;
+    private int experience = 0;
     // @salient - changed from 50 to 0, starting flu can be set in SO faction.
     private int influence = 0;
     private int technicians = 0; // @urgru 7/17/04
     private int currentTechPayment = -1; // num Cbills owed to techs after games
     private int teamNumber = -1;
     private int rewardPoints = 0;
+
     private double rating = INITIAL_RATING;
     private boolean isInvisible = false; // Evil command for Big brother err admins.
     private boolean autoReorderParts = false;
@@ -63,12 +68,52 @@ public class Player<T extends Unit> {
         Arrays.fill(availableTechs, 0);
     }
 
+    public House getMyHouse() {
+        return myHouse;
+    }
+
     public void setMyHouse(House house) {
         this.myHouse = house;
     }
 
-    public House getMyHouse() {
-        return myHouse;
+    public String getLogoTag() {
+        return "<img height=\"140\" width=\"130\" src =\"" + logo + "\">";
+    }
+
+    public String getLogo() {
+        return logo;
+    }
+
+
+    public void setLogo(String logo) {
+        logo = logo;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        if (name == null) {
+            throw new NullPointerException();
+        }
+        this.name = name;
+    }
+
+    public int getMoney() {
+        return money;
+    }
+
+    public void setMoney(int tmoney) {
+        money = tmoney;
+    }
+
+    public void setExperience(int experience) {
+        this.experience = experience;
+    }
+
+    public int getExperience() {
+        return experience;
     }
 
     public boolean isClan() {

--- a/MekWarsCommon/src/mekwars/common/Unit.java
+++ b/MekWarsCommon/src/mekwars/common/Unit.java
@@ -84,7 +84,6 @@ public class Unit {
     private int maintainanceLevel = 100;//@urgru 8/2/04
     private int unitC3Level = 0; //@Torren 12/13/04 0=None 1=Slave 2=Master 3=Independent
 
-    public int[] test = new int[4];
     public int simpleRepairCost = 0;
     private int currentRepairCost = 0;
     private int lifeTimeRepairCost = 0;

--- a/MekWarsCommon/src/mekwars/common/campaign/CampaignOptions.java
+++ b/MekWarsCommon/src/mekwars/common/campaign/CampaignOptions.java
@@ -21,8 +21,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Properties;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class CampaignOptions extends MekWarsConfig {
     private static final Logger LOGGER = LogManager.getLogger(CampaignOptions.class);

--- a/MekWarsCommon/src/mekwars/common/util/UnitUtils.java
+++ b/MekWarsCommon/src/mekwars/common/util/UnitUtils.java
@@ -95,6 +95,7 @@ public class UnitUtils {
     public static final int TECH_REG = 1;
     public static final int TECH_VET = 2;
     public static final int TECH_ELITE = 3;
+    public static final int TECH_TYPES = TECH_ELITE + 1;
     public static final int TECH_PILOT = 4;
     public static final int TECH_REWARD_POINTS = 5;
 
@@ -2084,6 +2085,9 @@ public class UnitUtils {
         }
         CriticalSlot cs = unit.getCritical(loc, slot);
 
+        if (cs == null) {
+            return 0;
+        }
         if (UnitUtils.isEngineCrit(cs)) {
             return UnitUtils.getNumberOfDamagedEngineCrits(unit);
         }
@@ -2139,7 +2143,6 @@ public class UnitUtils {
             }
             return damagedCrits;
         }
-
         return UnitUtils.getNumberOfDamagedSystemCriticals(unit, cs);
     }
 

--- a/MekWarsCommon/src/mekwars/common/util/UnitUtils.java
+++ b/MekWarsCommon/src/mekwars/common/util/UnitUtils.java
@@ -2073,9 +2073,7 @@ public class UnitUtils {
     }
 
     public static int getNumberOfDamagedCrits(Entity unit, int slot, int loc, boolean armor) {
-
         if (armor) {
-
             if (slot == UnitUtils.LOC_INTERNAL_ARMOR) {
                 return unit.getOInternal(loc) - unit.getInternal(loc);
             }

--- a/MekWarsCommon/unittests/mekwars/common/PlayerTest.java
+++ b/MekWarsCommon/unittests/mekwars/common/PlayerTest.java
@@ -1,0 +1,124 @@
+/*
+ * MekWars - Copyright (C) 2026
+ *
+ * Derived from MegaMekNET (http://www.sourceforge.net/projects/megameknet)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+package mekwars.common;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import mekwars.common.House;
+import mekwars.common.campaign.CampaignOptions;
+import mekwars.common.campaign.HouseOptions;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PlayerTest {
+
+    @Mock private CampaignData campaignData;
+
+    @Mock private CampaignOptions campaignOptions;
+
+    @Mock private HouseOptions houseOptions;
+
+    @Mock private House house;
+
+    private Player<Unit> player;
+
+    @BeforeEach
+    void setup() {
+        player = new Player<>();
+
+        player.setMyHouse(house);
+        when(campaignData.getCampaignOptions()).thenReturn(campaignOptions);
+    }
+
+    @Nested
+    class DoPayTechniciansMathTest {
+        @BeforeEach
+        void setup() {
+            CampaignData.cd = campaignData;
+            when(campaignOptions.getIntegerConfig("MaxTechsToHire")).thenReturn(-1);
+        }
+
+        @Test
+        void testDoPayTechniciansMath_ZeroTechnicians() {
+            player.setTechnicians(0);
+            player.doPayTechniciansMath();
+
+            // 0 technician = 0
+            assertEquals(0, player.getCurrentTechPayment());
+        }
+
+        @Test
+        void testDoPayTechniciansMath_NegativeAdditivePertech() {
+            player.setTechnicians(1);
+            when(houseOptions.getFloatConfig("AdditivePerTech")).thenReturn(-0.04f);
+            when(houseOptions.getFloatConfig("AdditiveCostCeiling")).thenReturn(1.20f);
+            when(house.getHouseOptions()).thenReturn(houseOptions);
+
+            player.doPayTechniciansMath();
+
+            // Invalid AdditivePerTech = 0
+            assertEquals(0, player.getCurrentTechPayment());
+        }
+
+        @Nested
+        class WithTechniciansTest {
+            @BeforeEach
+            void setup() {
+                when(houseOptions.getFloatConfig("AdditivePerTech")).thenReturn(0.04f);
+                when(houseOptions.getFloatConfig("AdditiveCostCeiling")).thenReturn(1.20f);
+                when(houseOptions.getBooleanConfig("UseSlidingHangarLimits")).thenReturn(false);
+                when(house.getHouseOptions()).thenReturn(houseOptions);
+            }
+
+            @Test
+            void testDoPayTechniciansMath_OneTechnician() {
+                player.setTechnicians(1);
+                player.doPayTechniciansMath();
+
+                // 1 technician = 1 * 0.04 = 0.04, rounded = 0
+                assertEquals(0, player.getCurrentTechPayment());
+            }
+
+            @Test
+            void testDoPayTechniciansMath_MultipleTechniciansBelowCeiling() {
+                player.setTechnicians(5);
+                player.doPayTechniciansMath();
+
+                // 1 + 2 + 3 + 4 + 5 = 15, 15 * 0.04 = 0.6, rounded = 1
+                assertEquals(1, player.getCurrentTechPayment());
+            }
+
+            @Test
+            void testDoPayTechniciansMath_TechniciansAboveCeiling() {
+                player.setTechnicians(35);
+                player.doPayTechniciansMath();
+
+                // First 30 techs: 1+2+...+30 = 465, 465 * 0.04 = 18.6
+                // Next 5 techs: 5 * 1.20 = 6.0
+                // Total: 18.6 + 6.0 = 24.6, rounded = 25
+                assertEquals(25, player.getCurrentTechPayment());
+            }
+        }
+    }
+}

--- a/MekWarsServer/src/mekwars/server/campaign/SPlayer.java
+++ b/MekWarsServer/src/mekwars/server/campaign/SPlayer.java
@@ -81,19 +81,13 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
     private static final String ACTIVE_MC = "activemc"; //@salient for minicampaigns
 
     // DATA VARIABLES (SAVED. Most have gets and sets.)
-    private String name = "";
     private String fluffText = "";
-    private String myLogo = "";
     private String lastISP = "";
 
-    private int experience = 0;
-    private int money = 0;
     private int xpTillReward = 0; // counter until next RP injection triggered by XP gains, see XPRollOverCap in server options
     private int xpTillFlu = 0; // @ Salient , same as above. counter until next flu injection triggered by XP gains.
     private int groupAllowance = 0;
-    private int technicians = 0;// @urgru 7/17/04
     private int baysOwned = 0;
-    private int currentTechPayment = -1;// num Cbills owed to techs after game
 
     private long lastOnline = 0;
 
@@ -192,7 +186,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
             return false;
         }
 
-        if (p.getName().equals(name)) {
+        if (p.getName().equals(getName())) {
             return true;
         }
 
@@ -222,22 +216,22 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
     public boolean mayUse(int weightClass) {
         //@Salient adding this in for Gunny
         if (weightClass == Unit.LIGHT) {
-            if (Integer.parseInt(getMyHouse().getConfig("MinEXPforLight")) > experience) {
+            if (Integer.parseInt(getMyHouse().getConfig("MinEXPforLight")) > getExperience()) {
                 return false;
             }
         }
         if (weightClass == Unit.MEDIUM) {
-            if (Integer.parseInt(getMyHouse().getConfig("MinEXPforMedium")) > experience) {
+            if (Integer.parseInt(getMyHouse().getConfig("MinEXPforMedium")) > getExperience()) {
                 return false;
             }
         }
         if (weightClass == Unit.HEAVY) {
-            if (Integer.parseInt(getMyHouse().getConfig("MinEXPforHeavy")) > experience) {
+            if (Integer.parseInt(getMyHouse().getConfig("MinEXPforHeavy")) > getExperience()) {
                 return false;
             }
         }
         if (weightClass == Unit.ASSAULT) {
-            if (Integer.parseInt(getMyHouse().getConfig("MinEXPforAssault")) > experience) {
+            if (Integer.parseInt(getMyHouse().getConfig("MinEXPforAssault")) > getExperience()) {
                 return false;
             }
         }
@@ -292,17 +286,17 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
          * above), along with total and free bay/tech info.
          */
         if (sendUpdates) {
-            CampaignMain.cm.toUser("PL|HD|" + m.toString(true), name, false);
-            CampaignMain.cm.toUser("PL|SUS|" + m.getId() + "#" + m.getStatus(), name, false);
-            CampaignMain.cm.toUser("PL|SB|" + getTotalMekBays(), name, false);
-            CampaignMain.cm.toUser("PL|SF|" + getFreeBays(), name, false);
+            CampaignMain.cm.toUser("PL|HD|" + m.toString(true), getName(), false);
+            CampaignMain.cm.toUser("PL|SUS|" + m.getId() + "#" + m.getStatus(), getName(), false);
+            CampaignMain.cm.toUser("PL|SB|" + getTotalMekBays(), getName(), false);
+            CampaignMain.cm.toUser("PL|SF|" + getFreeBays(), getName(), false);
         }
 
         // make sure to save the player, with his fancy new unit ...
         setSave();
 
         String penaltyString = buildHangarPenaltyString();
-        CampaignMain.cm.toUser("PL|SHP|" + penaltyString, name, false);
+        CampaignMain.cm.toUser("PL|SHP|" + penaltyString, getName(), false);
 
         //LOGGER.debug("Checking Anti-Air");
         //m.isAntiAir();
@@ -337,7 +331,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
     public String removeUnit(SUnit unitToRemove, boolean sendHouseStatusUpdate) {
         this.removeUnit(unitToRemove.getId(), true);
         String penaltyString = buildHangarPenaltyString();
-        CampaignMain.cm.toUser("PL|SHP|" + penaltyString, name, false);
+        CampaignMain.cm.toUser("PL|SHP|" + penaltyString, getName(), false);
         return "";// dummy stirng returned for IBuyer
     }
 
@@ -357,7 +351,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
             if (currA.getUnitPosition(unitId) > -1) {
                 currA.removeUnit(unitId);
                 if (sendArmyUpdate) {
-                    CampaignMain.cm.toUser("PL|SAD|" + currA.toString(true, "%"), name, false);
+                    CampaignMain.cm.toUser("PL|SAD|" + currA.toString(true, "%"), getName(), false);
                     CampaignMain.cm.getOpsManager().checkOperations(currA, true);// update
                     // legal
                     // ops
@@ -365,9 +359,9 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
             }
         }// end for(all armies)
 
-        CampaignMain.cm.toUser("PL|RU|" + unitId, name, false);
-        CampaignMain.cm.toUser("PL|SB|" + getTotalMekBays(), name, false);
-        CampaignMain.cm.toUser("PL|SF|" + getFreeBays(), name, false);
+        CampaignMain.cm.toUser("PL|RU|" + unitId, getName(), false);
+        CampaignMain.cm.toUser("PL|SB|" + getTotalMekBays(), getName(), false);
+        CampaignMain.cm.toUser("PL|SF|" + getFreeBays(), getName(), false);
         setSave();// save on remove (adminstrip, etc)
     }
 
@@ -472,7 +466,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
             // check for stupid settings to avoid division by 0
             if (experienceForBay != 0) {
                 int maxBaysFromXP = getMyHouse().getIntegerConfig("MaxBaysFromEXP");
-                int expBays = (experience / experienceForBay);
+                int expBays = (getExperience() / experienceForBay);
                 if (expBays > maxBaysFromXP) {
                     expBays = maxBaysFromXP;
                 }
@@ -579,7 +573,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
             int xpToDecrease = Integer.parseInt(getMyHouse().getConfig("XPForDecrease"));
             int minTechCost = Integer.parseInt(getMyHouse().getConfig("MinimumTechCost"));
 
-            int numDecreases = (int) Math.floor(experience / xpToDecrease);
+            int numDecreases = (int) Math.floor(getExperience() / xpToDecrease);
             techCost -= numDecreases;
 
             if (techCost < minTechCost) {
@@ -631,7 +625,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
             SUnit unit = okUnitsData.get(rnd);// get unit @ rnd location
             unit.setUnmaintainedStatus();// make it unmaintained
             numUnmaintained++;
-            CampaignMain.cm.toUser("PL|UU|" + unit.getId() + "|" + unit.toString(true), name, false);
+            CampaignMain.cm.toUser("PL|UU|" + unit.getId() + "|" + unit.toString(true), getName(), false);
             okUnitsData.remove(rnd);// and remove it from the vector
 
         }// end while(no free bays)
@@ -680,7 +674,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
                 else {
 
                     if (getMyHouse().isNewbieHouse()) {
-                        CampaignMain.cm.toUser("Your " + currUnit.getModelName() + " is badly maintained and failed a survival roll. In a normal faction, " + "failing these rolls <b>destroys</b> the unit. In the training faction you simply get this warning. Take heed.", name, true);
+                        CampaignMain.cm.toUser("Your " + currUnit.getModelName() + " is badly maintained and failed a survival roll. In a normal faction, " + "failing these rolls <b>destroys</b> the unit. In the training faction you simply get this warning. Take heed.", getName(), true);
                         return;
                     }// break out if trying to scrap a SOL mech
 
@@ -703,7 +697,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
                         toSend += CampaignMain.cm.moneyOrFluMessage(true, false, -mechscrapprice, true) + ", ";
                     }
                     toSend += CampaignMain.cm.moneyOrFluMessage(false, false, -flutolose, true) + ").";
-                    CampaignMain.cm.toUser(toSend, name, true);
+                    CampaignMain.cm.toUser(toSend, getName(), true);
 
                     getMyHouse().addDispossessedPilot(currUnit, false);
                     unitsToDestroy.add(currUnit);// actually removing now
@@ -753,8 +747,8 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
      */
     public void setActive(boolean newStatus) {
 
-        // lower case the name only once
-        String lowerName = name.toLowerCase();
+        // lower case the getName() only once
+        String lowerName = getName().toLowerCase();
 
         // de-activating
         if (!newStatus) {
@@ -782,7 +776,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
              * thread to hit the leach ceiling turn off any other attacks
              * against the player.
              */
-            CampaignMain.cm.getOpsManager().removePlayerFromAllPossibleDefenderLists(name, true);
+            CampaignMain.cm.getOpsManager().removePlayerFromAllPossibleDefenderLists(getName(), true);
 
             /*
              * Remove the player from all attacker lists. It is presumed that a
@@ -843,7 +837,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
     public void setFighting(boolean newStatus, boolean toReserve) {
 
         // lower case the name only once
-        String lowerName = name.toLowerCase();
+        String lowerName = getName().toLowerCase();
 
         // switch to fighting
         if (newStatus) {
@@ -856,7 +850,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
             getMyHouse().getFightingPlayers().put(lowerName, this);
 
             // send status update to the user
-            CampaignMain.cm.toUser("CS|" + +SPlayer.STATUS_FIGHTING, name, false);
+            CampaignMain.cm.toUser("CS|" + +SPlayer.STATUS_FIGHTING, getName(), false);
 
             /*
              * Player is being moved to busy status. This means he is no longer
@@ -923,13 +917,13 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
         activeSince = System.currentTimeMillis();
 
         // attempt to remove from both reserve AND active, just in case
-        String lowerName = name.toLowerCase();
+        String lowerName = getName().toLowerCase();
         getMyHouse().getReservePlayers().remove(lowerName);
         getMyHouse().getActivePlayers().remove(lowerName);
 
         // put the player in the fighting list and update status
         getMyHouse().getFightingPlayers().put(lowerName, this);
-        CampaignMain.cm.toUser("CS|" + +SPlayer.STATUS_FIGHTING, name, false);
+        CampaignMain.cm.toUser("CS|" + +SPlayer.STATUS_FIGHTING, getName(), false);
     }
 
     /**
@@ -1165,20 +1159,20 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
 
         armies.clear();
         clearUnits();
-        money = 0;
+        setMoney(0);
         exclusionList.getAdminExcludes().clear();
         exclusionList.getPlayerExcludes().clear();
-        experience = 0;
+        setExperience(0);
         baysOwned = 0;
         availableTechs = new int[UnitUtils.TECH_TYPES];
         totalTechs = new int[UnitUtils.TECH_TYPES];
-        technicians = 0;
+        setTechnicians(0);
         fluffText = " ";
         setRewardPoints(0);
         groupAllowance = 0;
         setInfluence(0);
         setMyHouse(CampaignData.cd.getHouseByName(getMyHouse().getConfig("NewbieHouseName")));
-        myLogo = " ";
+        setLogo(" ");
         personalPilotQueue.flushQueue();
         xpTillReward = 0;
         xpTillFlu = 0;
@@ -1195,7 +1189,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
      */
     public void addMoney(int i) {
         // holder, amount to store.
-        int moneyToSet = money + i;
+        int moneyToSet = getMoney() + i;
 
         // don't let SOL exceed cap, or anyone have negative cash
         int maxNewbieCbills = getMyHouse().getIntegerConfig("MaxSOLCBills");
@@ -1207,17 +1201,9 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
         }
 
         // change the value and send an update
-        money = moneyToSet;
-        CampaignMain.cm.toUser("PL|SM|" + money, name, false);
+        setMoney(moneyToSet);
+        CampaignMain.cm.toUser("PL|SM|" + getMoney(), getName(), false);
         setSave();
-    }
-
-    /**
-     * Get the amount of money the player currently has on hand. Required for
-     * IBuyer.
-     */
-    public int getMoney() {
-        return money;
     }
 
     /**
@@ -1226,7 +1212,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
     public void addMekToken(int i) {
         int tokenToSet = this.getMekToken() + i;
         this.setMekToken(tokenToSet);
-        CampaignMain.cm.toUser("PL|UMT|" + tokenToSet, name, false); //UMT: Update Mek Token on cplayer
+        CampaignMain.cm.toUser("PL|UMT|" + tokenToSet, getName(), false); //UMT: Update Mek Token on cplayer
         setSave();
     }
 
@@ -1278,7 +1264,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
      * STATUS_FIGHTING.
      */
     public int getDutyStatus() {
-        String lowerName = name.toLowerCase();
+        String lowerName = getName().toLowerCase();
 
         // Fighting
         if (getMyHouse().getFightingPlayers().containsKey(lowerName)) {
@@ -1313,7 +1299,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
         int xpForVote = Integer.parseInt(getMyHouse().getConfig("XPForAdditionalVote"));
         int maxVotes = Integer.parseInt(getMyHouse().getConfig("MaximumVotes"));
 
-        voteTotal += (int) Math.floor(experience / xpForVote);
+        voteTotal += (int) Math.floor(getExperience() / xpForVote);
         if (voteTotal > maxVotes) {
             voteTotal = maxVotes;
         }
@@ -1335,11 +1321,11 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
         armies.clear();
 
         if (sendStatus) {
-            CampaignMain.cm.toUser("PS|" + this.toString(true), name, false);
+            CampaignMain.cm.toUser("PS|" + this.toString(true), getName(), false);
         }
 
         setSave();
-        CampaignMain.cm.toUser("PL|SHP|" + buildHangarPenaltyString(), name, false);
+        CampaignMain.cm.toUser("PL|SHP|" + buildHangarPenaltyString(), getName(), false);
     }
 
     // EXPERIENCE SET/ADD/GET Methods
@@ -1354,31 +1340,31 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
      */
     public void addExperience(int i, boolean modAdded) {
         // change xp
-        experience += i;
+        setExperience(getExperience() + i);
 
         // check floor
-        if (experience < 0) {
-            experience = 0;
+        if (getExperience() < 0) {
+            setExperience(0);
         }
 
         // check SOL cap
-        if (getMyHouse().isNewbieHouse() && (experience > getMyHouse().getIntegerConfig("MaxSOLExp"))) {
-            experience = getMyHouse().getIntegerConfig("MaxSOLExp");
+        if (getMyHouse().isNewbieHouse() && (getExperience() > getMyHouse().getIntegerConfig("MaxSOLExp"))) {
+            setExperience(getMyHouse().getIntegerConfig("MaxSOLExp"));
         }
 
         // update client & all userlists
-        CampaignMain.cm.toUser("PL|SE|" + experience, name, false);
-        CampaignMain.cm.doSendToAllOnlinePlayers("PI|EX|" + name + "|" + experience, false);
+        CampaignMain.cm.toUser("PL|SE|" + getExperience(), getName(), false);
+        CampaignMain.cm.doSendToAllOnlinePlayers("PI|EX|" + getName() + "|" + getExperience(), false);
 
         // update corresponding small player.
-        SmallPlayer smallp = getMyHouse().getSmallPlayers().get(name.toLowerCase());
+        SmallPlayer smallp = getMyHouse().getSmallPlayers().get(getName().toLowerCase());
         if (smallp != null) {
-            smallp.setExperience(experience);
+            smallp.setExperience(getExperience());
         }
 
         // check and send mek bay numbers
-        CampaignMain.cm.toUser("PL|SB|" + getTotalMekBays(), name, false);
-        CampaignMain.cm.toUser("PL|SF|" + getFreeBays(), name, false);
+        CampaignMain.cm.toUser("PL|SB|" + getTotalMekBays(), getName(), false);
+        CampaignMain.cm.toUser("PL|SF|" + getFreeBays(), getName(), false);
 
         // check reward, if not mod added. never reduce rollover counter.
         if (!modAdded && (i > 0)) {
@@ -1402,7 +1388,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
                 // set up and send upe rp link
                 String toSend = "You earned " + rpToAdd + " experience " + CampaignMain.cm.getConfig("RPShortName");
                 toSend += "[<a href=\"MWUSERP\">Use " + CampaignMain.cm.getConfig("RPShortName") + "</a>]";
-                CampaignMain.cm.toUser(toSend, name, true);
+                CampaignMain.cm.toUser(toSend, getName(), true);
             } else {
                 setXpTillReward(currentXP);
             }
@@ -1428,17 +1414,13 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
                 setXpTillFlu(currentXP);
 
                 String toSend = "You earned " + fluToAdd + CampaignMain.cm.getConfig("FluShortName") + " by gaining xp!";
-                CampaignMain.cm.toUser(toSend, name, true);
+                CampaignMain.cm.toUser(toSend, getName(), true);
 
             } else {
                 setXpTillFlu(currentXP);
             }
         }
         setSave();
-    }
-
-    public int getExperience() {
-        return experience;
     }
 
     // SPECIAL USE METHODS (PRIVATE OR PUBLIC&STATIC)
@@ -1825,7 +1807,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
 
     //@salient - made a new command called RG (refresh gui) not really sure it works tbh..
     public void refreshGUI() {
-    	CampaignMain.cm.toUser("RG|" + " ", name, false);
+    	CampaignMain.cm.toUser("RG|" + " ", getName(), false);
     }
 
     //@salient
@@ -1838,9 +1820,9 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
     		aUnit.setLocked(false);
     	}
 
-        CampaignMain.cm.toUser("PS|" + this.toString(true), name, false);
+        CampaignMain.cm.toUser("PS|" + this.toString(true), getName(), false);
         setSave();
-        CampaignMain.cm.toUser("PL|SHP|" + buildHangarPenaltyString(), name, false);
+        CampaignMain.cm.toUser("PL|SHP|" + buildHangarPenaltyString(), getName(), false);
 
     	//refreshGUI();
     	toSelf("AM: Units have been unlocked!");
@@ -2024,20 +2006,16 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
     @Override
     public int getCurrentTechPayment() {
         // recalculate if -1
-        if (currentTechPayment < 0) {
+        if (super.getCurrentTechPayment() < 0) {
             doPayTechniciansMath();
         }
 
-        return currentTechPayment;
+        return super.getCurrentTechPayment();
     }
 
-    /**
-     * @param i
-     *            - post-game payment to set, in Cbills
-     */
     @Override
-    public void setCurrentTechPayment(int i) {
-        currentTechPayment = i;
+    public void setCurrentTechPayment(int techPayment) {
+        super.setCurrentTechPayment(techPayment);
         setSave();
     }
 
@@ -2049,8 +2027,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
         if (CampaignMain.cm.isUsingAdvanceRepair()) {
             return getBaysOwned();
         }
-        // else
-        return technicians;
+        return super.getTechnicians();
     }
 
     public String totalTechsToString() {
@@ -2086,7 +2063,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
             availableTechs[type] = number;
         }
 
-        CampaignMain.cm.toUser("PL|UAT|" + availableTechsToString(), name, false);
+        CampaignMain.cm.toUser("PL|UAT|" + availableTechsToString(), getName(), false);
 
     }
 
@@ -2102,7 +2079,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
         synchronized(totalTechs) {
             totalTechs[type] = number;
         }
-        CampaignMain.cm.toUser("PL|UTT|" + totalTechsToString(), name, false);
+        CampaignMain.cm.toUser("PL|UTT|" + totalTechsToString(), getName(), false);
     }
 
     public void updateAvailableTechs(String data) {
@@ -2171,9 +2148,9 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
     @Override
     public void setTechnicians(int t) {
         super.setTechnicians(t);
-        CampaignMain.cm.toUser("PL|ST|" + t, name, false);
-        CampaignMain.cm.toUser("PL|SB|" + getTotalMekBays(), name, false);
-        CampaignMain.cm.toUser("PL|SF|" + getFreeBays(), name, false);
+        CampaignMain.cm.toUser("PL|ST|" + t, getName(), false);
+        CampaignMain.cm.toUser("PL|SB|" + getTotalMekBays(), getName(), false);
+        CampaignMain.cm.toUser("PL|SF|" + getFreeBays(), getName(), false);
         setSave();
     }
 
@@ -2192,24 +2169,16 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
         }
     }
 
-    // NAME GET/SET METHODS
-    public String getName() {
-        return name;
-    }
-
     public String getColoredName() {
-        return "<font color=\"" + getHouseFightingFor().getHouseColor() + "\">" + name + "</font>";
+        return "<font color=\"" + getHouseFightingFor().getHouseColor() + "\">" + getName() + "</font>";
     }
 
     public String getColoredNameBold() { //@salient
-        return "<font color=\"" + getHouseFightingFor().getHouseColor() + "\"><b>" + name + "</b></font>";
+        return "<font color=\"" + getHouseFightingFor().getHouseColor() + "\"><b>" + getName() + "</b></font>";
     }
 
-    public void setName(String s) {
-        if (s == null) {
-            throw new NullPointerException();
-        }
-        name = s;
+    public void setName(String name) {
+        super.setName(name);
         setSave();
     }
     
@@ -2279,7 +2248,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
                 break;
             }
         }
-        CampaignMain.cm.toUser("PL|RA|" + armyID, name, false);
+        CampaignMain.cm.toUser("PL|RA|" + armyID, getName(), false);
     }
 
     public void setArmies(ArrayList<SArmy> v) {
@@ -2310,7 +2279,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
         } else if (getRating() < p.getRating()) {
             return -1;
         }
-        return p.getName().compareTo(name);
+        return p.getName().compareTo(getName());
     }
 
     public int getScrapsThisTick() {
@@ -2348,12 +2317,12 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
     public void setLastOnline(long l) {
         lastOnline = l;
         SmallPlayer smallp = null;
-        if (getMyHouse().getSmallPlayers().containsKey(name.toLowerCase())) {
+        if (getMyHouse().getSmallPlayers().containsKey(getName().toLowerCase())) {
             // update the corresponding small player.
-            smallp = getMyHouse().getSmallPlayers().get(name.toLowerCase());
+            smallp = getMyHouse().getSmallPlayers().get(getName().toLowerCase());
         } else {
             smallp = new SmallPlayer(getExperience(), lastOnline, getRating(), getName(), getFluffText(), getMyHouse());
-            getMyHouse().getSmallPlayers().put(name.toLowerCase(), smallp);
+            getMyHouse().getSmallPlayers().put(getName().toLowerCase(), smallp);
         }
 
         smallp.setLastOnline(lastOnline);
@@ -2371,14 +2340,14 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
         super.setRating(d);
 
         // update the corresponding small player.
-        SmallPlayer smallp = getMyHouse().getSmallPlayers().get(name.toLowerCase());
+        SmallPlayer smallp = getMyHouse().getSmallPlayers().get(getName().toLowerCase());
         smallp.setRating(getRating());
 
         // if sharing ratings, send to clients
         if (!Boolean.parseBoolean(getMyHouse().getConfig("HideELO"))) {
             double rounded = getRatingRounded();
-            CampaignMain.cm.toUser("PL|SR|" + rounded, name, false);
-            CampaignMain.cm.doSendToAllOnlinePlayers("PI|RA|" + name + "|" + rounded, false);
+            CampaignMain.cm.toUser("PL|SR|" + rounded, getName(), false);
+            CampaignMain.cm.doSendToAllOnlinePlayers("PI|RA|" + getName() + "|" + rounded, false);
         }
 
         setSave();
@@ -2395,7 +2364,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
         fluffText = s;
 
         // update the corresponding small player.
-        SmallPlayer smallp = getMyHouse().getSmallPlayers().get(name.toLowerCase());
+        SmallPlayer smallp = getMyHouse().getSmallPlayers().get(getName().toLowerCase());
         smallp.setFluffText(fluffText);
 
         setSave();
@@ -2433,7 +2402,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
         for (SArmy army : armies) {
             if (army.isUnitInArmy(unit)) {
                 army.setBV(0);
-                CampaignMain.cm.toUser("PL|SABV|" + army.getID() + "#" + army.getBV(), name, false);
+                CampaignMain.cm.toUser("PL|SABV|" + army.getID() + "#" + army.getBV(), getName(), false);
             }
         }
     }// end checkAndUpdateArmies
@@ -2449,13 +2418,13 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
     // set the current amount of reward points a player has.
     public void setRewardPoints(int rewardPoints) {
         super.setRewardPoints(rewardPoints);
-        CampaignMain.cm.toUser("PL|SRP|" + rewardPoints, name, false);
+        CampaignMain.cm.toUser("PL|SRP|" + rewardPoints, getName(), false);
         setSave();
     }
 
     public void setInfluence(int influence) {
         super.setInfluence(influence);
-        CampaignMain.cm.toUser("PL|SI|" + getInfluence(), name, false);
+        CampaignMain.cm.toUser("PL|SI|" + getInfluence(), getName(), false);
         setSave();
     }
 
@@ -2477,14 +2446,6 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
 
     public int getXpTillFlu() {
         return xpTillFlu;
-    }
-
-    public void setMyLogo(String s) {
-        myLogo = s;
-    }
-
-    public String getMyLogo() {
-        return myLogo;
     }
 
     public void setPlayerSellingto(String selling) {
@@ -2747,7 +2708,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
             }
         }
 
-        s.append("  " + CampaignMain.cm.moneyOrFluMessage(true, false, getMoney()) + " //  " + CampaignMain.cm.moneyOrFluMessage(false, false, getInfluence()) + " // " + experience + " Experience<br>");
+        s.append("  " + CampaignMain.cm.moneyOrFluMessage(true, false, getMoney()) + " //  " + CampaignMain.cm.moneyOrFluMessage(false, false, getInfluence()) + " // " + getExperience() + " Experience<br>");
 
         // advanced repair
         if (CampaignMain.cm.isUsingAdvanceRepair()) {
@@ -2913,9 +2874,9 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
     public String toString(boolean toClient) {
     	SerializedMessage result = new SerializedMessage("~");
         result.append("CP");
-        result.append(name);
-        result.append(money);
-        result.append(experience);
+        result.append(getName());
+        result.append(getMoney());
+        result.append(getExperience());
         result.append(getUnits().size());
         if (getUnits().size() > 0) {
             synchronized (getUnits()) {
@@ -2968,7 +2929,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
         if (CampaignMain.cm.isUsingAdvanceRepair()) {
             result.append(getBaysOwned());
         } else {
-            result.append(technicians);// used when saving to houses.dat
+            result.append(getTechnicians());// used when saving to houses.dat
         }
         // above is used when sending to client bad hack but needed for now
         result.append(getRewardPoints()); // saving current reward points
@@ -2987,10 +2948,10 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
         result.append(getMyHouse().getName() + " ");
         if (toClient) {
             result.append(getHouseFightingFor().getName() + " ");
-            if (getMyLogo().length() == 0) {
+            if (getLogo().length() == 0) {
                 result.append(getMyHouse().getLogo() + " ");
             } else {
-                result.append(getMyLogo() + " ");
+                result.append(getLogo() + " ");
             }
         } else {
             result.append(xpTillReward);
@@ -3006,12 +2967,12 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
             } else {
                 result.append(" ");
                 result.append(" ");
-                result.append(technicians);
+                result.append(getTechnicians());
             }
-            if (getMyLogo().trim().length() == 0) {
+            if (getLogo().trim().length() == 0) {
                 result.append(getMyHouse().getLogo() + " ");
             } else {
-                result.append(getMyLogo() + " ");
+                result.append(getLogo() + " ");
             }
             result.append(getLastAttackFromReserve());
             result.append(getGroupAllowance());
@@ -3077,10 +3038,10 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
              *
              * @urgru 4.2.05
              */
-            exclusionList.setOwnerName(name);
+            exclusionList.setOwnerName(getName());
 
-            money = TokenReader.readInt(ST);
-            experience = TokenReader.readInt(ST);
+            setMoney(TokenReader.readInt(ST));
+            setExperience(TokenReader.readInt(ST));
 
             int numofarmies = 0;
             int numofUnits = TokenReader.readInt(ST);
@@ -3090,19 +3051,19 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
                 SUnit m = new SUnit();
                 m.fromString((String) ST.nextElement());
                 addUnit(m);
-                CampaignMain.cm.toUser("PL|HD|" + m.toString(true), name, false);
+                CampaignMain.cm.toUser("PL|HD|" + m.toString(true), getName(), false);
             }
 
             numofarmies = (Integer.parseInt((String) ST.nextElement()));
             for (int i = 0; i < numofarmies; i++) {
-                SArmy a = new SArmy(name);
+                SArmy a = new SArmy(getName());
                 a.fromString((String) ST.nextElement(), "%", this);
                 if (armies.size() < a.getID()) {
                     armies.add(a);
                 } else {
                     armies.add(a.getID(), a);
                 }
-                CampaignMain.cm.toUser("PL|SAD|" + a.toString(true, "%"), name, false);
+                CampaignMain.cm.toUser("PL|SAD|" + a.toString(true, "%"), getName(), false);
             }
 
             setMyHouse(CampaignMain.cm.getHouseFromPartialString(TokenReader.readString(ST), null));
@@ -3134,7 +3095,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
                 // technicians = TokenReader.readInt(ST);
                 int te = TokenReader.readInt(ST);
                 int mt = CampaignMain.cm.getIntegerConfig("MaxTechsToHire");
-                technicians = (mt != -1) ? Math.min(te, mt) : te;
+                setTechnicians((mt != -1) ? Math.min(te, mt) : te);
             }
 
             setRewardPoints(TokenReader.readInt(ST));
@@ -3177,8 +3138,8 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
                         // allow servers to go back and forth using Bays as
                         // techs since bays are what techs are.
                         {
-                            if (technicians <= 0) {
-                                technicians = TokenReader.readInt(ST);
+                            if (getTechnicians() <= 0) {
+                                 setTechnicians(TokenReader.readInt(ST));
                             } else {
                                 TokenReader.readString(ST);
                             }
@@ -3190,7 +3151,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
                 }
             }// get rid of the 2 blanks
 
-            myLogo = TokenReader.readString(ST);
+            setLogo(TokenReader.readString(ST));
 
             // Stupid error with player logo if its blank it doesn't save
             // anything
@@ -3213,7 +3174,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
                 long time = TokenReader.readLong(ST);
 
                 if (passwd.trim().length() > 2) {
-                    setPassword(new MWPasswdRecord(name, access, passwd, time, ""));
+                    setPassword(new MWPasswdRecord(getName(), access, passwd, time, ""));
                 }
             } catch (Exception ex) {
                 // Issue with password loading just stop now.
@@ -3254,13 +3215,13 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
                 password.setAccess(IAuthenticator.GUEST);
             }
 
-            CampaignMain.cm.toUser("PL|SB|" + getTotalMekBays(), name, false);
-            CampaignMain.cm.toUser("PL|SF|" + getFreeBays(), name, false);
+            CampaignMain.cm.toUser("PL|SB|" + getTotalMekBays(), getName(), false);
+            CampaignMain.cm.toUser("PL|SF|" + getFreeBays(), getName(), false);
             if (CampaignMain.cm.isUsingAdvanceRepair()) {
 
                 if (!this.hasRepairingUnits()) {
-                    CampaignMain.cm.toUser("PL|UTT|" + totalTechsToString(), name, false);
-                    CampaignMain.cm.toUser("PL|UAT|" + totalTechsToString(), name, false);
+                    CampaignMain.cm.toUser("PL|UTT|" + totalTechsToString(), getName(), false);
+                    CampaignMain.cm.toUser("PL|UAT|" + totalTechsToString(), getName(), false);
                     updateAvailableTechs(totalTechsToString());// make
                     // sure
                     // techs
@@ -3268,8 +3229,8 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
                     // in
                     // synch
                 } else {
-                    CampaignMain.cm.toUser("PL|UTT|" + totalTechsToString(), name, false);
-                    CampaignMain.cm.toUser("PL|UAT|" + availableTechsToString(), name, false);
+                    CampaignMain.cm.toUser("PL|UTT|" + totalTechsToString(), getName(), false);
+                    CampaignMain.cm.toUser("PL|UAT|" + availableTechsToString(), getName(), false);
                 }
             }
 
@@ -3313,13 +3274,13 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
         unit.setPilot(pilot);
 
         // send an update to the player
-        CampaignMain.cm.toUser("PL|UU|" + unit.getId() + " |" + unit.toString(true), name, false);
+        CampaignMain.cm.toUser("PL|UU|" + unit.getId() + " |" + unit.toString(true), getName(), false);
 
         // correct the BV of any army which contains the unit
         for (SArmy currA : armies) {
             if (currA.getUnit(unit.getId()) != null) {
                 currA.setBV(0);
-                CampaignMain.cm.toUser("PL|SAD|" + currA.toString(true, "%"), name, false);
+                CampaignMain.cm.toUser("PL|SAD|" + currA.toString(true, "%"), getName(), false);
                 CampaignMain.cm.getOpsManager().checkOperations(currA, true);// update
                 // legal
                 // operations
@@ -3502,7 +3463,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
         }
 
         if (((elo > getRating()) || (exp > getExperience()))  && !CampaignMain.cm.getBooleanConfig("disableDemotionNotification") && !CampaignMain.cm.getBooleanConfig("autoPromoteSubFaction") ) {
-            StringBuilder message = new StringBuilder(name);
+            StringBuilder message = new StringBuilder(getName());
             message.append(" no longer meets the eligbility requirements for subfaction ");
             message.append(getSubFactionName());
             message.append(". He is eligible for the following:<br>");

--- a/MekWarsServer/src/mekwars/server/campaign/SPlayer.java
+++ b/MekWarsServer/src/mekwars/server/campaign/SPlayer.java
@@ -20,6 +20,7 @@ package mekwars.server.campaign;
 import java.math.BigDecimal;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.Iterator;
@@ -97,8 +98,6 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
     private long lastOnline = 0;
 
     private List<SArmy> armies = new ArrayList<>();
-    private List<Integer> totalTechs = new ArrayList<>();
-    private List<Integer> availableTechs = new ArrayList<>();
 
     private SPersonalPilotQueues personalPilotQueue = new SPersonalPilotQueues();
     private ExclusionList exclusionList = new ExclusionList();
@@ -151,13 +150,6 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
      * places - CampaignMain's load method and the EnrollCommand.
      */
     public SPlayer() {
-        // if using advanced repair, populate tech vectors and generate info
-        if (CampaignMain.cm.isUsingAdvanceRepair()) {
-            for (int x = 0; x < 4; x++) {
-                getAvailableTechs().add(0);
-                getTotalTechs().add(0);
-            }
-        }
         setMyHouse(CampaignData.cd.getHouseByName(CampaignData.cd.getCampaignOptions().getConfig("NewbieHouseName")));
     }
 
@@ -1178,8 +1170,8 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
         exclusionList.getPlayerExcludes().clear();
         experience = 0;
         baysOwned = 0;
-        availableTechs.clear();
-        totalTechs.clear();
+        availableTechs = new int[UnitUtils.TECH_TYPES];
+        totalTechs = new int[UnitUtils.TECH_TYPES];
         technicians = 0;
         fluffText = " ";
         setRewardPoints(0);
@@ -2061,14 +2053,6 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
         return technicians;
     }
 
-    public List<Integer> getTotalTechs() {
-        return totalTechs;
-    }
-
-    public List<Integer> getAvailableTechs() {
-        return availableTechs;
-    }
-
     public String totalTechsToString() {
         StringBuilder result = new StringBuilder();
 
@@ -2090,29 +2074,16 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
     }
 
     public void addAvailableTechs(int type, int number) {
-        if (type > UnitUtils.TECH_ELITE) {
-            return;
-        }
-
-        int techs = getAvailableTechs().get(type);
-
-        techs += number;
-
-        synchronized(availableTechs) {
-        	getAvailableTechs().set(type, techs);
-        }
-
-        CampaignMain.cm.toUser("PL|UAT|" + availableTechsToString(), name, false);
-
+        setAvailableTechs(type, getTotalTech(type) + number);
     }
 
     public void setAvailableTechs(int type, int number) {
-        if (type > UnitUtils.TECH_ELITE) {
+        if (type < 0 || type >= UnitUtils.TECH_TYPES) {
             return;
         }
 
         synchronized (availableTechs) {
-        	getAvailableTechs().set(type, number);
+            availableTechs[type] = number;
         }
 
         CampaignMain.cm.toUser("PL|UAT|" + availableTechsToString(), name, false);
@@ -2120,26 +2091,16 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
     }
 
     public void addTotalTechs(int type, int number) {
-        if (type > UnitUtils.TECH_ELITE) {
-            return;
-        }
-
-        int techs = getTotalTechs().get(type);
-        techs += number;
-        synchronized (totalTechs) {
-        	getTotalTechs().set(type, techs);
-        }
-
-        CampaignMain.cm.toUser("PL|UTT|" + totalTechsToString(), name, false);
+        setTotalTechs(type, getTotalTech(type) + number);
     }
 
     public void setTotalTechs(int type, int number) {
-        if (type > UnitUtils.TECH_ELITE) {
+        if (type < 0 || type >= UnitUtils.TECH_TYPES) {
             return;
         }
 
         synchronized(totalTechs) {
-        	getTotalTechs().set(type, number);
+            totalTechs[type] = number;
         }
         CampaignMain.cm.toUser("PL|UTT|" + totalTechsToString(), name, false);
     }
@@ -2153,8 +2114,8 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
                 techType++;
             }
         } catch (Exception ex) {
+            LOGGER.error("Unable to update available techs", ex);
         }
-
     }
 
     public void updateTotalTechs(String data) {
@@ -2167,8 +2128,8 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
                 techType++;
             }
         } catch (Exception ex) {
+            LOGGER.error("Unable to update total techs", ex);
         }
-
     }
 
     public int getBaysOwned() {
@@ -2790,8 +2751,8 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
 
         // advanced repair
         if (CampaignMain.cm.isUsingAdvanceRepair()) {
-            s.append("Technicians (Green/Reg/Vet/Elite): " + getTotalTechs().get(UnitUtils.TECH_GREEN) + "/" + getTotalTechs().get(UnitUtils.TECH_REG) + "/" + getTotalTechs().get(UnitUtils.TECH_VET) + "/" + getTotalTechs().get(UnitUtils.TECH_ELITE) + "<br>");
-            s.append("Idle Techs (Green/Reg/Vet/Elite):  " + getAvailableTechs().get(UnitUtils.TECH_GREEN) + "/" + getAvailableTechs().get(UnitUtils.TECH_REG) + "/" + getAvailableTechs().get(UnitUtils.TECH_VET) + "/" + getAvailableTechs().get(UnitUtils.TECH_ELITE) + "<br>");
+            s.append("Technicians (Green/Reg/Vet/Elite): " + getTotalTech(UnitUtils.TECH_GREEN) + "/" + getTotalTech(UnitUtils.TECH_REG) + "/" + getTotalTech(UnitUtils.TECH_VET) + "/" + getTotalTech(UnitUtils.TECH_ELITE) + "<br>");
+            s.append("Idle Techs (Green/Reg/Vet/Elite):  " + getAvailableTech(UnitUtils.TECH_GREEN) + "/" + getAvailableTech(UnitUtils.TECH_REG) + "/" + getAvailableTech(UnitUtils.TECH_VET) + "/" + getAvailableTech(UnitUtils.TECH_ELITE) + "<br>");
             s.append("Bays: " + getFreeBays() + "/" + getTotalMekBays() + "<br>");
             s.append("Leased Bays: " + getBaysOwned() + " (Cost: " + CampaignMain.cm.moneyOrFluMessage(true, false, getCurrentTechPayment()) + "/Game)<br>");
         }
@@ -3096,15 +3057,11 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
      *            name stuck on the end.
      */
     public void fromString(String s) {
-
         if (s == null) {
             throw new NullPointerException("SPlayer fromString(s) is null");
         }
 
-        // print the player into the info log. only for Debug
-        // LOGGER.info("CSPlayer: " + s);
         isLoading = true;
-
         try {
             armies.clear();
 
@@ -3169,7 +3126,8 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
                 int regTechs = greenTechs / 5;
                 greenTechs -= regTechs;
                 updateAvailableTechs(greenTechs + "%" + regTechs + "%0%0%");
-                getTotalTechs().addAll(getAvailableTechs());
+                
+                totalTechs = Arrays.copyOf(availableTechs, totalTechs.length);
                 // give them some bays
                 setBaysOwned(greenTechs + regTechs);
             } else {

--- a/MekWarsServer/src/mekwars/server/campaign/SPlayer.java
+++ b/MekWarsServer/src/mekwars/server/campaign/SPlayer.java
@@ -25,7 +25,6 @@ import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.List;
 import java.util.StringTokenizer;
-import java.util.Vector;
 
 import mekwars.common.CampaignData;
 import mekwars.common.Player;
@@ -66,7 +65,7 @@ import org.apache.logging.log4j.Logger;
  * - Moved slice flu generation to a Quartz task
  */
 
-public final class SPlayer extends Player implements Comparable<Object>, IBuyer, ISeller {
+public final class SPlayer extends Player<SUnit> implements Comparable<Object>, IBuyer, ISeller {
     private static final Logger LOGGER = LogManager.getLogger(SPlayer.class);
 
     // STATIC VARIABLES
@@ -86,10 +85,8 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     private String myLogo = "";
     private String lastISP = "";
 
-    private int money = 0;
     private int experience = 0;
-    private int influence = 0; //@salient - changed from 50 to 0, starting flu can be set in SO faction.
-    private int rewardPoints = 0; // number of rewards a player has. //@salient changed name to rewardPoints
+    private int money = 0;
     private int xpTillReward = 0; // counter until next RP injection triggered by XP gains, see XPRollOverCap in server options
     private int xpTillFlu = 0; // @ Salient , same as above. counter until next flu injection triggered by XP gains.
     private int groupAllowance = 0;
@@ -97,14 +94,11 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     private int baysOwned = 0;
     private int currentTechPayment = -1;// num Cbills owed to techs after game
 
-    private double rating = 1600;
-
     private long lastOnline = 0;
 
-    private Vector<SUnit> units = new Vector<SUnit>(1, 1);
-    private Vector<SArmy> armies = new Vector<SArmy>(1, 1);
-    private Vector<Integer> totalTechs = new Vector<Integer>(4, 1);
-    private Vector<Integer> availableTechs = new Vector<Integer>(4, 1);
+    private List<SArmy> armies = new ArrayList<>();
+    private List<Integer> totalTechs = new ArrayList<>();
+    private List<Integer> availableTechs = new ArrayList<>();
 
     private SPersonalPilotQueues personalPilotQueue = new SPersonalPilotQueues();
     private ExclusionList exclusionList = new ExclusionList();
@@ -134,13 +128,10 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     private Version clientVersion; // version gets sent by the player and
     // set
 
-    private SHouse myHouse;
     private MWPasswdRecord password = null;
 
     private UnitComponents unitParts = new UnitComponents();
 
-    private int DBId = 0;
-    private int forumID = 0;
     private boolean userValidated = false;
 
     boolean isLoading = false; // Player was getting saved multiple times
@@ -149,7 +140,6 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     // issues.
 
     private String subFaction = "";
-
     private long lastPromoted = 0;
 
     public volatile int leechCount = 0;
@@ -161,7 +151,6 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
      * places - CampaignMain's load method and the EnrollCommand.
      */
     public SPlayer() {
-
         // if using advanced repair, populate tech vectors and generate info
         if (CampaignMain.cm.isUsingAdvanceRepair()) {
             for (int x = 0; x < 4; x++) {
@@ -169,8 +158,18 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
                 getTotalTechs().add(0);
             }
         }
-        myHouse = CampaignMain.cm.getHouseFromPartialString(CampaignMain.cm.getConfig("NewbieHouseName"));
+        setMyHouse(CampaignData.cd.getHouseByName(CampaignData.cd.getCampaignOptions().getConfig("NewbieHouseName")));
+    }
 
+    /* TODO: This is unwanted but necessary. We need to cast here because we get compile errors for
+     * two reasons
+     * 1. CampaignData.cm.getHouse returns a House but is used by both the client and server so it
+     *   cannot be modified.
+     * 2. SHouse has a legacy getHouseConfig method that points to
+     *   CampaignData.cm.getCampaignOptions()
+     */
+    public SHouse getMyHouse() {
+        return (SHouse) super.getMyHouse();
     }
 
     /**
@@ -216,7 +215,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
      * @return the rounded rating
      */
     public double getRatingRounded() {
-        BigDecimal bd = new BigDecimal(rating);
+        BigDecimal bd = new BigDecimal(getRating());
         bd = bd.setScale(2, BigDecimal.ROUND_HALF_UP);
         return bd.doubleValue();
     }
@@ -257,9 +256,8 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
      * Add a unit to the player. Pass-though to addUnit(SUnit,boolean,boolean).
      * This version should be called in almost all situations.
      */
-    public void addUnit(SUnit m, boolean isNew) 
-    {
-			this.addUnit(m, isNew, true);
+    public void addUnit(SUnit m, boolean isNew) {
+        this.addUnit(m, isNew, true);
     }
 
     /**
@@ -269,7 +267,6 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
      * bandwidth is saved by doing a single PS| at the end of a series of adds.
      */
     public String addUnit(SUnit m, boolean isNew, boolean sendUpdates) {
-
         if (isNew) {
             long immunityTime = Long.parseLong(getMyHouse().getConfig("ImmunityTime")) * 1000;
             m.setPassesMaintainanceUntil(System.currentTimeMillis() + immunityTime * 2);
@@ -289,12 +286,11 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
         }
 
         // strip illegal ammo
-        SUnit.checkAmmoForUnit(m, myHouse);
+        SUnit.checkAmmoForUnit(m, getMyHouse());
         
         m.setPosId(getFreeID());
-        synchronized(units) 
-        {   
-        	units.add(m);
+        synchronized(getUnits()) {
+            addUnit(m);
         }
 
         /*
@@ -330,13 +326,11 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
      * @return the desired unit, or null.
      */
     public SUnit getUnit(int id) {
-
-        for (SUnit currU : units) {
+        for (SUnit currU : getUnits()) {
             if (currU.getId() == id) {
                 return currU;
             }
         }
-
         return null;
     }
 
@@ -365,11 +359,11 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
      */
     public void removeUnit(int unitid, boolean sendArmyUpdate) {
         SUnit Mech = null;
-        synchronized (units) {
-        	for (int i = 0; i < units.size(); i++) {
-        		Mech = units.elementAt(i);
+        synchronized (getUnits()) {
+        	for (int i = 0; i < getUnits().size(); i++) {
+        		Mech = getUnits().get(i);
         		if (Mech.getId() == unitid) {
-        			units.removeElementAt(i);
+        			getUnits().remove(i);
         		}
             }
         }
@@ -399,7 +393,6 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
      * @return number of free bays/techs
      */
     public int getFreeBays() {
-
         int free = getTotalMekBays();
         int totalProtos = 0;
         boolean advanceRep = CampaignMain.cm.isUsingAdvanceRepair();
@@ -412,7 +405,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
          * determines exactly how many techs are needed for any ProtoMek
          * grouping.  Christmas gifts are excluded from cost.
          */
-        for (SUnit currU : units) {
+        for (SUnit currU : getUnits()) {
 
             if (((currU.getStatus() == Unit.STATUS_OK) || (currU.getStatus() == Unit.STATUS_FORSALE)) && (!currU.isChristmasUnit())) {
                 if (CampaignMain.cm.isUsingIncreasedTechs()) {
@@ -461,8 +454,8 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     public int getTotalMekBays() {// return bay/support number
         int numBays = 0;// amount to return
 
-        boolean usesXP = Boolean.parseBoolean(getMyHouse().getConfig("UseExperience"));
-        boolean usesTechs = Boolean.parseBoolean(getMyHouse().getConfig("UseTechnicians"));
+        boolean usesXP = getMyHouse().getBooleanConfig("UseExperience");
+        boolean usesTechs = getMyHouse().getBooleanConfig("UseTechnicians");
         boolean usesAdvanceRepairs = CampaignMain.cm.isUsingAdvanceRepair();
 
         if (usesAdvanceRepairs) {
@@ -471,7 +464,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
 
         // include the basic bays. flat amount for mercs/SOL, warehouse # for
         // GreatHouses
-        int BASE_BAYS = myHouse.getBaysProvided();
+        int BASE_BAYS = getMyHouse().getBaysProvided();
         numBays += BASE_BAYS;
 
         /*
@@ -481,8 +474,8 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
          * dropping fresh-from-SOL players to an unacceptably low # of bays.
          * Don't give these to mercenaries.
          */
-        if (!myHouse.isMercHouse()) {
-            int minBays = Integer.parseInt(getMyHouse().getConfig("MinimumHouseBays"));
+        if (!getMyHouse().isMercHouse()) {
+            int minBays = getMyHouse().getIntegerConfig("MinimumHouseBays");
             if (numBays < minBays) {
                 numBays = minBays;
             }
@@ -490,10 +483,10 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
 
         // then add the bays from XP, if the config says to...
         if (usesXP) {
-            int experienceForBay = Integer.parseInt(getMyHouse().getConfig("ExperienceForBay"));
+            int experienceForBay = getMyHouse().getIntegerConfig("ExperienceForBay");
             // check for stupid settings to avoid division by 0
             if (experienceForBay != 0) {
-                int maxBaysFromXP = Integer.parseInt(getMyHouse().getConfig("MaxBaysFromEXP"));
+                int maxBaysFromXP = getMyHouse().getIntegerConfig("MaxBaysFromEXP");
                 int expBays = (experience / experienceForBay);
                 if (expBays > maxBaysFromXP) {
                     expBays = maxBaysFromXP;
@@ -516,100 +509,6 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
 
         return numBays;
     }// end TotalMechBays()
-
-    /**
-     * This method does all the math to figure out how much the retainer fee,
-     * maintenance cost, whathaveyou is for the current number of technicians.
-     * The number itself is useful in some cases (let people know what they will
-     * have to pay after hiring a new tech, for example), and thus separated
-     * from the actual payment. For now, we have only one payment calculation
-     * mechanism -- additive costing, whereby each tech costs as much as the
-     * last, plus a constant kicker. A cap to this cost can be configured;
-     * however, it must be a multiple of the per-tech additive (eg, if the
-     * additive is .04, 1.20 would be a valid cap, but 1.30 wouldn't).
-     *
-     * @urgru 7/26/04
-     */
-    private void doPayTechniciansMath() {
-
-        int techs = getTechnicians();
-
-        // don't even waste time on 0 cases. Just return.
-        if (techs <= 0) {
-            setCurrentTechPayment(0);
-            return;
-        }
-
-        // starts as a double, gets cast back to an int for return.
-        float amountToPay = 0;
-
-        // load config variables needed to do the math ...
-        float additive = Float.parseFloat(getMyHouse().getConfig("AdditivePerTech"));
-        float ceiling = Float.parseFloat(getMyHouse().getConfig("AdditiveCostCeiling"));
-
-        /*
-         * divide the ceiling by the addiive. techs past this number are all
-         * charged at the ceiling rate. Example: (With 1.20 and .04, the result
-         * is 30. Every additional tech (31, 32, etc.) is paid at the ceiling
-         * wage.
-         */
-        int techCeiling = (int) (ceiling / additive);
-        if (techs > techCeiling) {
-            int techsPastCeiling = techs - techCeiling;
-            amountToPay += ceiling * techsPastCeiling;
-        }// end if(some techs are paid @ ceiling price)
-
-        /*
-         * Add up the number of times the non-ceiling techs were incremented,
-         * then figure out their total cost. In cases where the ceiling is
-         * passed, the flat fee techs are handled above, so only techs up to
-         * that ceiling need to have the additive math done. If the ceiling isnt
-         * reached, just use the number of techToPay from the param.
-         */
-        int techsUsingAdditive = 0;
-        if (techs > techCeiling) {
-            techsUsingAdditive = techCeiling;
-        } else {
-            techsUsingAdditive = techs;
-        }
-
-        /*
-         * Faster to just to a for loop to determine the number of times the
-         * additive was made (1 + 2 + 3 + 4, and so on) with ints, and THEN
-         * multiply by the double additive than do alot of floating point math
-         * by for-in through and multiplying by the additive each time.
-         */
-        int totalAdditions = 0;
-        for (int i = 1; i <= techsUsingAdditive; i++) {
-            totalAdditions += i;
-        }
-
-        // now figure out the final amount to pay ...
-        amountToPay += totalAdditions * additive;
-
-        // Add penalty if the player is over a sliding limit
-
-        for(int type_id = Unit.MEK; type_id < Unit.MAXBUILD; type_id ++) {
-            for (int weightclass = Unit.LIGHT; weightclass <= Unit.ASSAULT; weightclass++) {
-                if (hasHangarPenalty(type_id, weightclass)) {
-                    int costPenalty = calculateHangarPenalty(type_id, weightclass);
-                    amountToPay += costPenalty;
-                }
-            }
-        }
-        /*
-         * now return the amount in INT form since we don't support fractional
-         * money. also, set the currentTechPayment, to avoid doing this math
-         * again if possible.
-         */
-        int toSet = Math.round(amountToPay);
-        if (toSet < 0) {
-            toSet = 0;
-        }// don't pay players to add techs.
-
-        setCurrentTechPayment(toSet);
-
-    }// end doPayTechnicians(arbitrary number)
 
     /**
      * Should be called only after an attempt to pay techs comes up short. At
@@ -727,8 +626,8 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
 
         // filter out units which are already unmaintained, for_sale or
         // destroyed
-        Vector<SUnit> okUnitsData = new Vector<SUnit>(1, 1);
-        for (SUnit currU : units) {
+        ArrayList<SUnit> okUnitsData = new ArrayList<>();
+        for (SUnit currU : getUnits()) {
             if (currU.getStatus() == Unit.STATUS_OK) {
                 okUnitsData.add(currU);
             }
@@ -744,7 +643,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
             int rnd = CampaignMain.cm.getRandomNumber(okUnitsData.size());// generate
             // a
             // RND
-            SUnit unit = okUnitsData.elementAt(rnd);// get unit @ rnd location
+            SUnit unit = okUnitsData.get(rnd);// get unit @ rnd location
             unit.setUnmaintainedStatus();// make it unmaintained
             numUnmaintained++;
             CampaignMain.cm.toUser("PL|UU|" + unit.getId() + "|" + unit.toString(true), name, false);
@@ -769,7 +668,6 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
      * off BM nulls.
      */
     public void doMaintainance() {
-
         if (CampaignMain.cm.isUsingAdvanceRepair()) {
             return;
         }
@@ -777,7 +675,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
         int decrease = Integer.parseInt(getMyHouse().getConfig("MaintainanceDecrease"));
 
         ArrayList<SUnit> unitsToDestroy = new ArrayList<SUnit>();
-        for (SUnit currUnit : units) {// loops through all units
+        for (SUnit currUnit : getUnits()) {// loops through all units
 
             // if the unit is maintained, boost its level
             if (currUnit.getStatus() == Unit.STATUS_OK) {
@@ -796,14 +694,14 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
                 // unmaintained and failed scrap check. blow 'er up.
                 else {
 
-                    if (myHouse.isNewbieHouse()) {
+                    if (getMyHouse().isNewbieHouse()) {
                         CampaignMain.cm.toUser("Your " + currUnit.getModelName() + " is badly maintained and failed a survival roll. In a normal faction, " + "failing these rolls <b>destroys</b> the unit. In the training faction you simply get this warning. Take heed.", name, true);
                         return;
                     }// break out if trying to scrap a SOL mech
 
                     // if scrapping costs bills, subtract the appropriate
                     // amount.
-                    int mechscrapprice = Math.round(myHouse.getPriceForUnit(currUnit.getWeightclass(), currUnit.getType()) * Float.parseFloat(getMyHouse().getConfig("ScrapCostMultiplier")));
+                    int mechscrapprice = Math.round(getMyHouse().getPriceForUnit(currUnit.getWeightclass(), currUnit.getType()) * Float.parseFloat(getMyHouse().getConfig("ScrapCostMultiplier")));
                     if (getMoney() < mechscrapprice) {
                         mechscrapprice = getMoney();
                     }
@@ -822,7 +720,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
                     toSend += CampaignMain.cm.moneyOrFluMessage(false, false, -flutolose, true) + ").";
                     CampaignMain.cm.toUser(toSend, name, true);
 
-                    myHouse.addDispossessedPilot(currUnit, false);
+                    getMyHouse().addDispossessedPilot(currUnit, false);
                     unitsToDestroy.add(currUnit);// actually removing now
                     // would cause conc mod
                     // error
@@ -851,7 +749,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
      */
     public boolean hasUnmaintainedUnit() {
 
-        for (SUnit currU : units) {
+        for (SUnit currU : getUnits()) {
             if (currU.getStatus() == Unit.STATUS_UNMAINTAINED) {
                 return true;
             }
@@ -912,8 +810,8 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
 
             // all done. remove the player from the active hash and put him in
             // reserve
-            myHouse.getActivePlayers().remove(lowerName);
-            myHouse.getReservePlayers().put(lowerName, this);
+            getMyHouse().getActivePlayers().remove(lowerName);
+            getMyHouse().getReservePlayers().put(lowerName, this);
 
             // NOTE: Deactivation does NOT call IThread.removeImmunity(). This
             // lets SOL reset units.
@@ -938,8 +836,8 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
             olh.sendInfoToOpponents("is headed to the front lines. You may attack it with ");
 
             // make the hash switch
-            myHouse.getReservePlayers().remove(lowerName);
-            myHouse.getActivePlayers().put(lowerName, this);
+            getMyHouse().getReservePlayers().remove(lowerName);
+            getMyHouse().getActivePlayers().put(lowerName, this);
         }
     }
 
@@ -969,8 +867,8 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
              * remove the player (if present) from the active list, then add him
              * to the fighting hashtable.
              */
-            myHouse.getActivePlayers().remove(lowerName);
-            myHouse.getFightingPlayers().put(lowerName, this);
+            getMyHouse().getActivePlayers().remove(lowerName);
+            getMyHouse().getFightingPlayers().put(lowerName, this);
 
             // send status update to the user
             CampaignMain.cm.toUser("CS|" + +SPlayer.STATUS_FIGHTING, name, false);
@@ -990,8 +888,8 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
         // de-fight from AFR. Move to reserve.
         else if (toReserve) {
             activeSince = 0;
-            myHouse.getFightingPlayers().remove(lowerName);
-            myHouse.getReservePlayers().put(lowerName, this);
+            getMyHouse().getFightingPlayers().remove(lowerName);
+            getMyHouse().getReservePlayers().put(lowerName, this);
             // Unschedule his activity jobs
             UserActivityComponentsJob.stop(getName());
             UserActivityInfluenceJob.stop(getName());
@@ -1003,8 +901,8 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
              * remove the player (if present) from the active list, then add him
              * to the fighting hashtable.
              */
-            myHouse.getFightingPlayers().remove(lowerName);
-            myHouse.getActivePlayers().put(lowerName, this);
+            getMyHouse().getFightingPlayers().remove(lowerName);
+            getMyHouse().getActivePlayers().put(lowerName, this);
 
             /*
              * If player was STATUS_FIGHTING and is being moved back into
@@ -1041,11 +939,11 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
 
         // attempt to remove from both reserve AND active, just in case
         String lowerName = name.toLowerCase();
-        myHouse.getReservePlayers().remove(lowerName);
-        myHouse.getActivePlayers().remove(lowerName);
+        getMyHouse().getReservePlayers().remove(lowerName);
+        getMyHouse().getActivePlayers().remove(lowerName);
 
         // put the player in the fighting list and update status
-        myHouse.getFightingPlayers().put(lowerName, this);
+        getMyHouse().getFightingPlayers().put(lowerName, this);
         CampaignMain.cm.toUser("CS|" + +SPlayer.STATUS_FIGHTING, name, false);
     }
 
@@ -1068,11 +966,10 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
      * @author urgru 10/27/04
      */
     public double getWeightedArmyNumber() {
-
         // only get the weight if it hasnt been calculated already.
         if (weightedArmyNumber <= 0) {
 
-            Vector<SArmy> orderedArmies = new Vector<SArmy>(1, 1);
+            ArrayList<SArmy> orderedArmies = new ArrayList<>();
 
             LOGGER.debug("Start getWeightedArmyNumber for " + getName());
             int MinCount = getMyHouse().getIntegerConfig("MinCountForTick");
@@ -1082,7 +979,6 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
             double MaxPercentDiff = 0.0;
 
             for (SArmy currentArmy : getArmies()) {
-
                 // only count armies within the defined Min/Max range
                 int forceBV = currentArmy.getOperationsBV(null);
                 if (forceBV <= MinCount) {
@@ -1129,11 +1025,12 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
                 if (orderedArmies.size() == 0) {
                     orderedArmies.add(currentArmy);
                 } else {// size > 0
-                    Enumeration<SArmy> f = orderedArmies.elements();
+                    Iterator<SArmy> f = orderedArmies.iterator();
                     int forceNumber = 0;// number of current army
                     boolean forceSorted = false;
-                    while (f.hasMoreElements() && !forceSorted) {
-                        if (currentArmy.getOperationsBV(null) < (f.nextElement()).getOperationsBV(null)) {
+
+                    while (f.hasNext() && !forceSorted) {
+                        if (currentArmy.getOperationsBV(null) < (f.next()).getOperationsBV(null)) {
                             orderedArmies.add(forceNumber, currentArmy);
                             forceSorted = true;
                         } else {
@@ -1164,9 +1061,8 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
             weightedArmyNumber *= weightMod;
 
             if (weightedArmyNumber > 0) {
-
-                Enumeration<SArmy> e = orderedArmies.elements();
-                SArmy currentArmy = e.nextElement();// get first army
+                Iterator<SArmy> e = orderedArmies.iterator();
+                SArmy currentArmy = e.next();// get first army
                 int currentBV = currentArmy.getOperationsBV(null);
 
                 // holder for whichever is greater - flat diff or percent
@@ -1194,10 +1090,9 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
                  */
                 SArmy nextArmy = null;// for use in loop
                 int nextBV = 0;// for use in loop
-                while (e.hasMoreElements()) {// loop through remaining forces
-
+                while (e.hasNext()) {// loop through remaining forces
                     // get the next army, and its BV
-                    nextArmy = e.nextElement();
+                    nextArmy = e.next();
                     nextBV = nextArmy.getOperationsBV(null);
 
                     /*
@@ -1279,13 +1174,12 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     }
 
     public void reset(String confirm) {
-
         if (!confirm.equals("CONFIRM")) {
             return;
         }
 
         armies.clear();
-        units.clear();
+        clearUnits();
         money = 0;
         exclusionList.getAdminExcludes().clear();
         exclusionList.getPlayerExcludes().clear();
@@ -1295,13 +1189,12 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
         totalTechs.clear();
         technicians = 0;
         fluffText = " ";
-        rewardPoints = 0;
+        setRewardPoints(0);
         groupAllowance = 0;
-        influence = 0;
-        myHouse = CampaignMain.cm.getHouseFromPartialString(getMyHouse().getConfig("NewbieHouseName"), null);
+        setInfluence(0);
+        setMyHouse(CampaignData.cd.getHouseByName(getMyHouse().getConfig("NewbieHouseName")));
         myLogo = " ";
         personalPilotQueue.flushQueue();
-        rating = 1600;
         xpTillReward = 0;
         xpTillFlu = 0;
         setMekToken(0);
@@ -1316,13 +1209,12 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
      * there is no need for a public SPlayer.setMoney() method.
      */
     public void addMoney(int i) {
-
         // holder, amount to store.
         int moneyToSet = money + i;
 
         // don't let SOL exceed cap, or anyone have negative cash
-        int maxNewbieCbills = Integer.parseInt(getMyHouse().getConfig("MaxSOLCBills"));
-        if (myHouse.isNewbieHouse() && (moneyToSet > maxNewbieCbills)) {
+        int maxNewbieCbills = getMyHouse().getIntegerConfig("MaxSOLCBills");
+        if (getMyHouse().isNewbieHouse() && (moneyToSet > maxNewbieCbills)) {
             moneyToSet = maxNewbieCbills;
         }
         if (moneyToSet < 0) {
@@ -1347,16 +1239,13 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
      * @ Salient for free build, mek tokens iterate up to the server limit. Updates CPlayer.
      */
     public void addMekToken(int i) {
-
         int tokenToSet = this.getMekToken() + i;
         this.setMekToken(tokenToSet);
         CampaignMain.cm.toUser("PL|UMT|" + tokenToSet, name, false); //UMT: Update Mek Token on cplayer
         setSave();
-
     }
 
     public void setPassword(MWPasswdRecord pass) {
-
         if (pass == null) {
             try {
                 throw new Exception();
@@ -1381,13 +1270,6 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     }
 
     /**
-     * Simple method that returns a player's faction.
-     */
-    public SHouse getMyHouse() {
-        return myHouse;
-    }
-
-    /**
      * Method which determines which house a player is actually fighting for.
      * Used to display contracting house, instead of real faction, for
      * mercenaries.
@@ -1401,7 +1283,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
      * Enroll commands.
      */
     public void setMyHouse(SHouse h) {
-        myHouse = h;
+        super.setMyHouse(h);
         setSave();
     }
 
@@ -1411,21 +1293,20 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
      * STATUS_FIGHTING.
      */
     public int getDutyStatus() {
-
         String lowerName = name.toLowerCase();
 
         // Fighting
-        if (myHouse.getFightingPlayers().containsKey(lowerName)) {
+        if (getMyHouse().getFightingPlayers().containsKey(lowerName)) {
             return SPlayer.STATUS_FIGHTING;
         }
 
         // Active
-        if (myHouse.getActivePlayers().containsKey(lowerName)) {
+        if (getMyHouse().getActivePlayers().containsKey(lowerName)) {
             return STATUS_ACTIVE;
         }
 
         // Logged into house
-        if (myHouse.getReservePlayers().containsKey(lowerName)) {
+        if (getMyHouse().getReservePlayers().containsKey(lowerName)) {
             return SPlayer.STATUS_RESERVE;
         }
 
@@ -1465,8 +1346,8 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
      *            which send status on its own after granting new units.
      */
     public void stripOfAllUnits(boolean sendStatus) {
-        units = new Vector<SUnit>(1, 1);
-        armies = new Vector<SArmy>(1, 1);
+        clearUnits();
+        armies.clear();
 
         if (sendStatus) {
             CampaignMain.cm.toUser("PS|" + this.toString(true), name, false);
@@ -1487,7 +1368,6 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
      *            - true if added from a mod/admin command
      */
     public void addExperience(int i, boolean modAdded) {
-
         // change xp
         experience += i;
 
@@ -1497,8 +1377,8 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
         }
 
         // check SOL cap
-        if (myHouse.isNewbieHouse() && (experience > Integer.parseInt(getMyHouse().getConfig("MaxSOLExp")))) {
-            experience = Integer.parseInt(getMyHouse().getConfig("MaxSOLExp"));
+        if (getMyHouse().isNewbieHouse() && (experience > getMyHouse().getIntegerConfig("MaxSOLExp"))) {
+            experience = getMyHouse().getIntegerConfig("MaxSOLExp");
         }
 
         // update client & all userlists
@@ -1506,7 +1386,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
         CampaignMain.cm.doSendToAllOnlinePlayers("PI|EX|" + name + "|" + experience, false);
 
         // update corresponding small player.
-        SmallPlayer smallp = myHouse.getSmallPlayers().get(name.toLowerCase());
+        SmallPlayer smallp = getMyHouse().getSmallPlayers().get(name.toLowerCase());
         if (smallp != null) {
             smallp.setExperience(experience);
         }
@@ -1517,20 +1397,19 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
 
         // check reward, if not mod added. never reduce rollover counter.
         if (!modAdded && (i > 0)) {
-
             int currentXP = xpTillReward + i;
-            int rollOver = (Integer.parseInt(getMyHouse().getConfig("XPRollOverCap")));
+            int rollOver = getMyHouse().getIntegerConfig("XPRollOverCap");
 
             // if XP is over rollover point, reduce until below again
             if ((currentXP >= rollOver) && (rollOver > 0)) {
-
                 int rpToAdd = 0;
+
                 while (currentXP >= rollOver) {
                     currentXP -= rollOver;
                     rpToAdd++;
                 }
 
-                addReward(rpToAdd);
+                addRewardPoints(rpToAdd);
 
                 // reset the counter
                 setXpTillReward(currentXP);
@@ -1539,26 +1418,21 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
                 String toSend = "You earned " + rpToAdd + " experience " + CampaignMain.cm.getConfig("RPShortName");
                 toSend += "[<a href=\"MWUSERP\">Use " + CampaignMain.cm.getConfig("RPShortName") + "</a>]";
                 CampaignMain.cm.toUser(toSend, name, true);
-
             } else {
                 setXpTillReward(currentXP);
             }
         }
 
         //@salient
-        if (!modAdded && (i > 0))
-        {
-
+        if (!modAdded && (i > 0)) {
             int currentXP = xpTillFlu + i;
-            int rollOver = (Integer.parseInt(getMyHouse().getConfig("FluXPRollOverCap")));
+            int rollOver = getMyHouse().getIntegerConfig("FluXPRollOverCap");
 
             // if XP is over rollover point, reduce until below again
-            if ((currentXP >= rollOver) && (rollOver > 0))
-            {
-
+            if ((currentXP >= rollOver) && (rollOver > 0)) {
                 int fluToAdd = 0;
-                while (currentXP >= rollOver)
-                {
+
+                while (currentXP >= rollOver) {
                     currentXP -= rollOver;
                     fluToAdd++;
                 }
@@ -1571,13 +1445,10 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
                 String toSend = "You earned " + fluToAdd + CampaignMain.cm.getConfig("FluShortName") + " by gaining xp!";
                 CampaignMain.cm.toUser(toSend, name, true);
 
-            }
-            else
-            {
+            } else {
                 setXpTillFlu(currentXP);
             }
         }
-
         setSave();
     }
 
@@ -1599,40 +1470,34 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
      */
     public int getHangarBV() {
         int bv = 0;
-        for (SUnit currU : units) {
+        for (SUnit currU : getUnits()) {
             bv += currU.getBVForMatch();
         }
         return bv;
     }
 
     //@salient - do the same as above but also some other BV calcs.
-    public int getHangarBVforMC()
-    {
+    public int getHangarBVforMC() {
         int bv = 0;
         boolean removeLockedBV = getMyHouse().getBooleanConfig("LockedUnits_RemoveBV");
         boolean ignoreAeroBV = getMyHouse().getBooleanConfig("IgnoreAeroBV");
 
-        for (SUnit currU : units)
-        {
-            if(removeLockedBV) // do not add BV of units that are locked.
-            {
-            	if(currU.isLocked() == false) //if unit is locked, ignore it
-            	{
+        for (SUnit currU : getUnits()) {
+            if(removeLockedBV) { // do not add BV of units that are locked. 
+            	if(currU.isLocked() == false) { //if unit is locked, ignore it
             		if(ignoreAeroBV && currU.getType() == 5) // ignore aero units
             			continue;
             		else
             			bv += currU.getBVForMatch();
             	}
             }
-            else // add up all unit bv
-            {
+            else { // add up all unit bv
         		if(ignoreAeroBV && currU.getType() == 5) // ignore aero units
         			continue;
         		else
         			bv += currU.getBVForMatch();
             }
         }
-
         return bv;
     }
 
@@ -1647,8 +1512,8 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
         boolean found = false;
         while (!found) {
             found = true;
-            for (int i = 0; i < units.size(); i++) {
-                if (units.get(i).getPosId() == id) {
+            for (int i = 0; i < getUnits().size(); i++) {
+                if (getUnits().get(i).getPosId() == id) {
                     found = false;
                     id++;
                 }
@@ -1663,7 +1528,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
         while (!free) {
             free = true;
             for (int j = 0; j < getArmies().size(); j++) {
-                if (getArmies().elementAt(j).getID() == i) {
+                if (getArmies().get(j).getID() == i) {
                     free = false;
                     i++;
                 }
@@ -1682,8 +1547,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     public boolean mayAcquireWelfareUnits() {
 
         if ((getHangarBV() < getMyHouse().getIntegerConfig("WelfareTotalUnitBVCeiling"))
-        && (getMoney() < getMyHouse().getIntegerConfig("WelfareCeiling")))
-        {
+        && (getMoney() < getMyHouse().getIntegerConfig("WelfareCeiling"))) {
             return true;
         }
 
@@ -1697,25 +1561,21 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
      * @return if enabled, this method will initiate the Restock Phase (currency injection)
      * 		   if hangar is below a certain threshold. This occurs AFTER a match.
      */
-    public void checkHangarRestockMC()
-    {
+    public void checkHangarRestockMC() {
     	boolean enabledMC = getMyHouse().getBooleanConfig("Enable_MiniCampaign");
     	boolean lockUnits = getMyHouse().getBooleanConfig("LockUnits");
 
     	//adding this in before method exit, since i want to be able to allow
     	//unit locking while mini campaign is disabled yes locked units is not
     	int lockedLimit = getMyHouse().getIntegerConfig("UnlockUnits_Percentage");
-    	if ( !enabledMC && lockUnits && lockedLimit != -1)
-    	{
-    		if (percentLockedUnitsMC() >= lockedLimit)
-    		{
+    	if ( !enabledMC && lockUnits && lockedLimit != -1) {
+    		if (percentLockedUnitsMC() >= lockedLimit) {
     			unlockAllUnitsMC();
     			setSave();
     		}
     	}
 
-    	if(!enabledMC)
-    	{
+    	if(!enabledMC) {
     		toSelf("AM: Mini Campaigns are disabled on the server!");
     		return;
     	}
@@ -1740,16 +1600,14 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     	int restockMT = getMyHouse().getIntegerConfig("RestockMT_Injection");
 
     	//check if we should restock
-    	if( minBVLimit != -1 && getHangarBVforMC() < minBVLimit )
-    	{
+    	if( minBVLimit != -1 && getHangarBVforMC() < minBVLimit ) {
     		restock = true;
     		minBVRestock = true;
 
             LOGGER.info("{} has gone under BV limit and a restock should occur", getName());
     	}
 
-    	if( percentBVLimit != -1 && getHangarBVforMC() < getBVResetPointMC() )
-    	{
+    	if( percentBVLimit != -1 && getHangarBVforMC() < getBVResetPointMC() ) {
     		restock = true;
     		percentRestock = true;
     		setBVTracker(0); //return this to default zero. on activation, it will be set to new value.
@@ -1757,67 +1615,58 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
             LOGGER.info("{} has gone under % BV limit and a restock should occur", getName());
     	}
 
-    	if( minUnitLimit != -1 && getUnitCountMC() < minUnitLimit )
-    	{
+    	if( minUnitLimit != -1 && getUnitCountMC() < minUnitLimit ) {
     		restock = true;
     		unitRestock = true;
 
     		LOGGER.info(getName() + " has gone under Unit limit and a restock should occur");
     	}
 
-    	if( !restock && !minBVRestock && minBVLimit != -1)
-    	{
+    	if( !restock && !minBVRestock && minBVLimit != -1) {
     		toSelf("AM: Your hangar is at "+ getHangarBVforMC() + "BV. When you drop below "
     				+ minBVLimit + "BV your mini campaign will restart");
     	}
 
-    	if ( !restock && !percentRestock && percentBVLimit != -1)
-    	{
+    	if ( !restock && !percentRestock && percentBVLimit != -1) {
     		toSelf("AM: Your hangar is at "+ getHangarBVforMC() + "BV. When you drop below "
     				+ getBVResetPointMC() + "BV your mini campaign will restart");
     	}
 
-    	if ( !restock && !unitRestock && minUnitLimit != -1)
-    	{
+    	if ( !restock && !unitRestock && minUnitLimit != -1) {
     		toSelf("AM: Your hangar is at "+ getUnitCountMC() + "Units. When you drop below "
     				+ minUnitLimit + "Units your mini campaign will restart");
     	}
 
     	//if too many of the players units are locked to continue, unlock all units
-    	if ( !restock && lockUnits && lockedLimit != -1) //do only if feature enabled
-    		if (percentLockedUnitsMC() >= lockedLimit)
-    		{
+    	if ( !restock && lockUnits && lockedLimit != -1) { //do only if feature enabled
+    		if (percentLockedUnitsMC() >= lockedLimit) {
     			unlockAllUnitsMC(); // sets save now
     			//setSave();
     		}
+        }
 
-    	if( !restock )
-    	{
+    	if( !restock ) {
     		setSave(); // needed since shortresolver handles unit locking
     					// though i have to imagine it also saves in shortresolver somewhere...
     		return;
     	}
 
-    	if( restock ) //the way it's set up, may not need to clear currency since it should be clear already.
-    	{
-        	if( restockRP != -1 )
-        	{
-        		addReward(-getReward()); //clear before reset
-        		addReward(restockRP);
-        		toSelf("AM: You have received " + getReward() + " " + CampaignMain.cm.getConfig("RPLongName")
+    	if( restock ) { //the way it's set up, may not need to clear currency since it should be clear already.
+        	if( restockRP != -1 ) {
+        		addRewardPoints(-getRewardPoints()); //clear before reset
+        		addRewardPoints(restockRP);
+        		toSelf("AM: You have received " + getRewardPoints() + " " + CampaignMain.cm.getConfig("RPLongName")
         			+ ". Restock your forces before continuing.");
         	}
 
-        	if( restockFLU != -1 )
-        	{
+        	if( restockFLU != -1 ) {
         		addInfluence(-getInfluence()); //clear before reset
         		addInfluence(restockFLU);
         		toSelf("AM: You have received " + getInfluence() + " " + CampaignMain.cm.getConfig("FluLongName")
         			+ ". Restock your forces before continuing.");
         	}
 
-        	if( restockMT != -1 )
-        	{
+        	if( restockMT != -1 ) {
         		addMekToken(-getMekToken()); // clear
         		addMekToken(getMekTokenLimit());//have to go to limit to clear to 0, counts up
         		addMekToken(-restockMT); //subtract since it counts up
@@ -1825,8 +1674,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
         			+ " free mek tokens. Restock your forces before continuing.");
         	}
 
-        	if( restockCB != -1 )
-        	{
+        	if( restockCB != -1 ) {
         		addMoney(-getMoney()); // clear
         		addMoney(restockCB);
         		toSelf("AM: You have received " + getMoney() + " " + CampaignMain.cm.getConfig("MoneyLongName")
@@ -1846,10 +1694,8 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
      * @author Salient
      * @return checks if a player can go active for the next cycle in his/her mini campaign
      */
-    public boolean canActivateForMiniCampaign()
-    {
-    	if(!getMyHouse().getBooleanConfig("Enable_MiniCampaign"))
-    	{
+    public boolean canActivateForMiniCampaign() {
+    	if(!getMyHouse().getBooleanConfig("Enable_MiniCampaign")) {
     		toSelf("AM: Mini Campaigns are disabled on the server!");
     		return false;
     	}
@@ -1879,60 +1725,50 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     	//boolean canActivate = true;
 
     	//check if hangar BV has increased (maybe via salvage? or trades?), if so update to new value.
-        if ( percentBVLimit != -1  && getHangarBVforMC() > getBVTracker() )
-        {
+        if (percentBVLimit != -1  && getHangarBVforMC() > getBVTracker()) {
         	setBVTracker(getHangarBVforMC());
         	LOGGER.info(getName() + "'s BV reset point set to " + getBVResetPointMC() + " BV");
         }
         
-        if(isPhaseRestockMC())
-        {       	
-        	if ( minBVLimit != -1  && getHangarBVforMC() < minBVLimit )
-        	{
+        if(isPhaseRestockMC()) {
+        	if (minBVLimit != -1  && getHangarBVforMC() < minBVLimit) {
         		toSelf("AM: To go active you must raise your hangar BV! You have " + getHangarBVforMC()
         		+ " and need at least " + minBVLimit + " to go active!");
         		return false;
         	}
         	
-        	if ( minUnitLimit != -1  && getUnitCountMC() < minUnitLimit )
-        	{
+        	if (minUnitLimit != -1  && getUnitCountMC() < minUnitLimit) {
         		toSelf("AM: To go active you must raise your hangar Unit Count! You have " + getUnitCountMC()
         		+ " and need at least " + minUnitLimit + " to go active!");
         		return false;
         	}
         	
-        	if( restockCB != -1 && leewayCB > 0f && getMoney() > leewayCB )
-        	{
+        	if (restockCB != -1 && leewayCB > 0f && getMoney() > leewayCB) {
         		toSelf("AM: You have too many " + CampaignMain.cm.getCurrencyName("money", false) + " to go active!" );
         		return false;
         	}
         	
-        	if( restockRP != -1 && leewayRP > 0f && getReward() > leewayRP )
-        	{
+        	if (restockRP != -1 && leewayRP > 0f && getRewardPoints() > leewayRP) {
         		toSelf("AM: You have too many " + CampaignMain.cm.getCurrencyName("rp", false) + " to go active!" );
         		return false;
         	}
         	
-        	if( restockFLU != -1 && leewayFLU > 0f && getInfluence() > leewayFLU )
-        	{
+        	if (restockFLU != -1 && leewayFLU > 0f && getInfluence() > leewayFLU) {
         		toSelf("AM: You have too much " + CampaignMain.cm.getCurrencyName("flu", false) + " to go active!" );
         		return false;
         	}
         	
-        	if( restockMT != -1 && leewayMT > 0f && getRemainingMekTokens() > leewayMT )
-        	{
+        	if (restockMT != -1 && leewayMT > 0f && getRemainingMekTokens() > leewayMT) {
         		toSelf("AM: You must use up more of your free meks to go active!" );
         		return false;
         	}
         	
-        	if ( requireUnitsAtOrOverLimit && isPhaseRestockMC() && isAtOrOverUnitLimits() == false )
-        	{
+        	if (requireUnitsAtOrOverLimit && isPhaseRestockMC() && isAtOrOverUnitLimits() == false) {
         		toSelf("AM: You must reach or exceed the limit for each unit type/weight before "
         				+ "restarting your mini campaign!");
         		return false;
         	}
-        	else if ( requireUnitsAtLimit && isPhaseRestockMC() && isAtUnitLimits() == false )
-        	{
+        	else if (requireUnitsAtLimit && isPhaseRestockMC() && isAtUnitLimits() == false) {
         		toSelf("AM: You must reach the limit for each unit type/weight before restarting your "
         				+ "mini campaign!");
         		return false;
@@ -1941,12 +1777,10 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
         	//At this point we assume that the player can activate and leave restock state.
 			removeInjectedCurrencyMC(restockCB, restockRP, restockFLU, restockMT);
 
-			if ( percentBVLimit != -1 )
-			{
+			if (percentBVLimit != -1) {
 				setBVTracker(getHangarBVforMC());// set new hangar BV for tracking
 				LOGGER.info(getName() + "'s BV reset point set to " + getBVResetPointMC() + " BV");
 			}
-			
     		setPhaseActiveMC();
     		setSave();
         }
@@ -1956,26 +1790,22 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     }
 
     //@salient will be used here and in a command.
-    public void reportStatusMC()
-    {
+    public void reportStatusMC() {
     	int minBVLimit = getMyHouse().getIntegerConfig("MinBV_HangarRestock");
     	int percentBVLimit = getMyHouse().getIntegerConfig("Percent_HangarRestock");
     	int minUnitLimit = getMinUnitResetMC();
 
-		if ( percentBVLimit != -1 )
-		{
+		if (percentBVLimit != -1) {
 			toSelf("AM: Current Hangar BV: " + getHangarBVforMC());
 			toSelf("AM: Next mini campaign cycle will begin when your hangar BV falls below " + getBVResetPointMC());
 		}
 
-		if ( minUnitLimit != -1 )
-		{
+		if (minUnitLimit != -1) {
 			toSelf("AM: Current Unit Count: " + getUnitCountMC());
 			toSelf("AM: Next mini campaign cycle will if your Unit Count falls below " + minUnitLimit);
 		}
 
-        if ( minBVLimit != -1 )
-        {
+        if (minBVLimit != -1) {
 			toSelf("AM: Current Hangar BV: " + getHangarBVforMC());
 			toSelf("AM: Next mini campaign cycle will begin when your hangar BV falls below " + minBVLimit);
         }
@@ -1984,15 +1814,13 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
 
 
     // -- MC DATA SAVE/LOAD --
-    private String saveStatusMC()
-    {
+    private String saveStatusMC() {
     	SerializedMessage result = new SerializedMessage("&");
     	result.append(phaseMC);
     	return result.toString();
     }
 
-    private void loadStatusMC(String data)
-    {
+    private void loadStatusMC(String data) {
     	StringTokenizer st = new StringTokenizer(data, "&");
     	if(st.hasMoreTokens())
     		phaseMC = TokenReader.readString(st);
@@ -2000,8 +1828,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     		LOGGER.error("loadStatusMC failed! no token available for phaseMC");
     }
 
-    private boolean isPhaseRestockMC()
-    {
+    private boolean isPhaseRestockMC() {
     	if(phaseMC.equalsIgnoreCase(RESTOCK_MC))
     		return true;
     	else
@@ -2012,20 +1839,17 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     private void setPhaseRestockMC() {	phaseMC = RESTOCK_MC;	}
 
     //@salient - made a new command called RG (refresh gui) not really sure it works tbh..
-    public void refreshGUI()
-    {
+    public void refreshGUI() {
     	CampaignMain.cm.toUser("RG|" + " ", name, false);
     }
 
     //@salient
-    public void unlockAllUnitsMC()
-    {
-
-    	if(!getMyHouse().getBooleanConfig("LockUnits"))
+    public void unlockAllUnitsMC() {
+    	if(!getMyHouse().getBooleanConfig("LockUnits")) {
     		return;
+        }
 
-    	for (SUnit aUnit : getUnits())
-    	{
+    	for (SUnit aUnit : getUnits()) {
     		aUnit.setLocked(false);
     	}
 
@@ -2062,8 +1886,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
      * @author Salient
      * 			adds rewards to player at end of mini campaign cycle
      */
-    private void addRewardsMC()
-    {        
+    private void addRewardsMC() {
         int rewardBays = this.getMyHouse().getIntegerConfig("MC_Reward_BAYS");
         int rewardTechs = this.getMyHouse().getIntegerConfig("MC_Reward_TECHS");
         int rewardXP = this.getMyHouse().getIntegerConfig("MC_Reward_XP");
@@ -2075,20 +1898,17 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
         this.addBays(rewardBays);
         this.addTechnicians(rewardTechs);
         this.addExperience(rewardXP, false);
-        this.addReward(rewardRP);
+        this.addRewardPoints(rewardRP);
         this.addInfluence(rewardFLU);
         this.addMoney(rewardCB);
         this.addMekToken(-rewardMT); // counts up to limit
-    	
     }
 
     //@salient - returns the percent of players units that are locked.
-    public int percentLockedUnitsMC()
-    {
+    public int percentLockedUnitsMC() {
     	int numLocked = 0;
 
-    	for (SUnit aUnit : getUnits())
-    	{
+    	for (SUnit aUnit : getUnits()) {
     		if(aUnit.isLocked())
     			numLocked++;
     	}
@@ -2100,58 +1920,48 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     }
 
     //@salient
-    private void removeInjectedCurrencyMC(int restockCB, int restockRP, int restockFLU, int restockMT)
-    {
-    	if(hasMoney() && restockCB != -1)
-    	{
+    private void removeInjectedCurrencyMC(int restockCB, int restockRP, int restockFLU, int restockMT) {
+    	if(hasMoney() && restockCB != -1) {
     		addMoney(-getMoney());
     	}
 
-    	if(hasRP() && restockRP != -1)
-    	{
-    		addReward(-getReward());
+    	if(hasRP() && restockRP != -1) {
+    		addRewardPoints(-getRewardPoints());
     	}
 
-    	if(hasFlu() && restockFLU != -1)
-    	{
+    	if(hasFlu() && restockFLU != -1) {
     		addInfluence(-getInfluence());
     	}
 
-    	if(hasMT() && restockMT != -1)
-    	{
+    	if(hasMT() && restockMT != -1) {
     		addMekToken(-getMekToken()); // clear
     		addMekToken(getMekTokenLimit());//have to go to limit to clear to 0, counts up
     	}
     }
 
     //@salient - using a percentage set by SO, this returns the BV at which point the mini campaign will end
-    private int getBVResetPointMC()
-    {
+    private int getBVResetPointMC() {
     	float percent = getMyHouse().getIntegerConfig("Percent_HangarRestock") / 100.0f;
     	int resetPt = (int) (getBVTracker() * percent);
     	return resetPt;
     }
 
     //@salient - using a value set by SO, this returns the Unit count at which point the mini campaign will end
-    private int getMinUnitResetMC()
-    {
+    private int getMinUnitResetMC() {
     	int resetPt = getMyHouse().getIntegerConfig("Unit_HangarRestock");
     	return resetPt;
     }
 
     // -- DISCORD BOT DATA SAVE/LOAD --
-    private String saveDiscordInfo()
-    {
+    private String saveDiscordInfo() {
     	SerializedMessage result = new SerializedMessage("&");
     	result.append(discordID);
     	return result.toString();
     }
 
-    private void loadDiscordInfo(String data)
-    {
+    private void loadDiscordInfo(String data) {
 		StringTokenizer st = new StringTokenizer(data, "&");
-		if(st.hasMoreTokens())
-		{
+		if(st.hasMoreTokens()) {
 			discordID = TokenReader.readString(st);
 		}
 		else
@@ -2160,28 +1970,25 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
 
 
     //@salient
-    public void removeCurrency()
-    {
+    public void removeCurrency() {
     	addMoney(-getMoney());
     	addInfluence(-getInfluence());
-    	addReward(-getReward());
+    	addRewardPoints(-getRewardPoints());
 
 		addMekToken(-getMekToken()); // clear
 		addMekToken(getMekTokenLimit());//have to go to limit to clear to 0, counts up
     }
 
     //@salient
-    public boolean hasCurrency()
-    {
-    	if( getMoney() != 0 || getInfluence() != 0 || getReward() != 0 || getRemainingMekTokens() != 0 )
+    public boolean hasCurrency() {
+    	if( getMoney() != 0 || getInfluence() != 0 || getRewardPoints() != 0 || getRemainingMekTokens() != 0 )
     		return true;
     	else
     		return false;
     }
 
     //@salient
-    public boolean hasMoney()
-    {
+    public boolean hasMoney() {
     	if( getMoney() != 0 )
     		return true;
     	else
@@ -2189,8 +1996,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     }
 
     //@salient
-    public boolean hasFlu()
-    {
+    public boolean hasFlu() {
     	if( getInfluence() != 0 )
     		return true;
     	else
@@ -2198,17 +2004,15 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     }
 
     //@salient
-    public boolean hasRP()
-    {
-    	if( getReward() != 0 )
+    public boolean hasRP() {
+    	if( getRewardPoints() != 0 )
     		return true;
     	else
     		return false;
     }
 
     //@salient
-    public boolean hasMT()
-    {
+    public boolean hasMT() {
     	if( getRemainingMekTokens() != 0 )
     		return true;
     	else
@@ -2216,29 +2020,17 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     }
 
     //@salient
-    public int getRemainingMekTokens()
-    {
+    public int getRemainingMekTokens() {
     	int limit = getMyHouse().getIntegerConfig("FreeBuild_Limit");
 
     	return limit - getMekToken(); //mek tokens count up to limit
     }
 
     //@salient
-    public int getMekTokenLimit()
-    {
+    public int getMekTokenLimit() {
     	int limit = Integer.parseInt(getMyHouse().getConfig("FreeBuild_Limit"));
 
     	return limit; //mek tokens count up to limit
-    }
-
-    /**
-     * A method to add a specified amount of influence
-     *
-     * @param i
-     *            - amount of influence to add
-     */
-    public void addInfluence(int i) {
-        setInfluence(getInfluence() + i);
     }
 
     /**
@@ -2246,7 +2038,6 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
      */
     @Override
     public int getCurrentTechPayment() {
-
         // recalculate if -1
         if (currentTechPayment < 0) {
             doPayTechniciansMath();
@@ -2277,20 +2068,17 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
         return technicians;
     }
 
-    public Vector<Integer> getTotalTechs() {
+    public List<Integer> getTotalTechs() {
         return totalTechs;
     }
 
-    public Vector<Integer> getAvailableTechs() {
+    public List<Integer> getAvailableTechs() {
         return availableTechs;
     }
 
     public String totalTechsToString() {
         StringBuilder result = new StringBuilder();
 
-        // Make sure that we keep it as size 4. Had some early issues with rouge
-        // vectors.
-        getTotalTechs().setSize(4);
         for (Integer tech : getTotalTechs()) {
             result.append(tech + "%");
         }
@@ -2301,9 +2089,6 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     public String availableTechsToString() {
         StringBuilder result = new StringBuilder();
 
-        // Make sure that we keep it as size 4. Had some early issues with rouge
-        // vectors.
-        getAvailableTechs().setSize(4);
         for (Integer tech : getAvailableTechs()) {
             result.append(tech + "%");
         }
@@ -2312,12 +2097,11 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     }
 
     public void addAvailableTechs(int type, int number) {
-
         if (type > UnitUtils.TECH_ELITE) {
             return;
         }
 
-        int techs = getAvailableTechs().elementAt(type);
+        int techs = getAvailableTechs().get(type);
 
         techs += number;
 
@@ -2330,7 +2114,6 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     }
 
     public void setAvailableTechs(int type, int number) {
-
         if (type > UnitUtils.TECH_ELITE) {
             return;
         }
@@ -2344,12 +2127,11 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     }
 
     public void addTotalTechs(int type, int number) {
-
         if (type > UnitUtils.TECH_ELITE) {
             return;
         }
 
-        int techs = getTotalTechs().elementAt(type);
+        int techs = getTotalTechs().get(type);
         techs += number;
         synchronized (totalTechs) {
         	getTotalTechs().set(type, techs);
@@ -2401,7 +2183,6 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     }
 
     public void setBaysOwned(int bays) {
-
         int maxBays = 0;
 
         if (getMyHouse() != null) {
@@ -2435,28 +2216,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
      */
     @Override
     public void setTechnicians(int t) {
-
-        int maxTechs = 0;
-
-        // dont allow negative techs. always set negatives back to 0.
-        if (t < 0) {
-            t = 0;
-        }
-
-        if (getMyHouse() != null) {
-            maxTechs = Integer.parseInt(getMyHouse().getConfig("MaxTechsToHire"));
-        } else {
-            maxTechs = CampaignMain.cm.getIntegerConfig("MaxTechsToHire");
-        }
-
-        if (maxTechs != -1) {
-            technicians = Math.min(maxTechs, t);
-        } else {
-            technicians = t;
-        }
-
-        // clear the tech payment any time a new number of techs is set
-        setCurrentTechPayment(-1);
+        super.setTechnicians(t);
         CampaignMain.cm.toUser("PL|ST|" + t, name, false);
         CampaignMain.cm.toUser("PL|SB|" + getTotalMekBays(), name, false);
         CampaignMain.cm.toUser("PL|SF|" + getFreeBays(), name, false);
@@ -2492,7 +2252,6 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     }
 
     public void setName(String s) {
-
         if (s == null) {
             throw new NullPointerException();
         }
@@ -2506,10 +2265,8 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     }
     
     //@salient
-    public void setDiscordID(String _discordID)
-    {
-        if ( _discordID == null || _discordID == "" )
-        {
+    public void setDiscordID(String _discordID) {
+        if ( _discordID == null || _discordID == "" ) {
         	toSelf("AM:You must enter a discord ID to set!");
             return;
         }
@@ -2547,22 +2304,19 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
 //    }
 
     public SArmy getArmy(int id) {
-
         for (SArmy currA : armies) {
             if (currA.getID() == id) {
                 return currA;
             }
         }
-
         return null;
     }
 
-    public Vector<SArmy> getArmies() {
+    public List<SArmy> getArmies() {
         return armies;
     }
 
     public void removeArmy(int armyID) {
-
         Iterator<SArmy> i = armies.iterator();
         while (i.hasNext()) {
             SArmy currA = i.next();
@@ -2574,36 +2328,23 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
         CampaignMain.cm.toUser("PL|RA|" + armyID, name, false);
     }
 
-    public void setArmies(Vector<SArmy> v) {
+    public void setArmies(ArrayList<SArmy> v) {
         armies = v;
         setSave();
     }
 
-    public Vector<SUnit> getUnits() {
-        return units;
-    }
-
-    //@salient
-    public int getUnitCount() {
-        return units.size();
-    }
-
     //@salient - includes SO check to count only unlocked units LockedUnits_DecrementUnitCount
-    private int getUnitCountMC()
-    {
-    	if(getMyHouse().getBooleanConfig("LockedUnits_DecrementUnitCount"))
-    	{
+    private int getUnitCountMC() {
+    	if(getMyHouse().getBooleanConfig("LockedUnits_DecrementUnitCount")) {
 	    	int count = 0;
-	    	for(SUnit aUnit : units)
-	    	{
+	    	for(SUnit aUnit : getUnits()) {
 	    		if(aUnit.isLocked() == false)
 	    			count++;
 	    	}
 	    	return count;
     	}
-    	else
-    	{
-    		return units.size();
+    	else {
+    		return getUnits().size();
     	}
     }
 
@@ -2653,12 +2394,12 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     public void setLastOnline(long l) {
         lastOnline = l;
         SmallPlayer smallp = null;
-        if (myHouse.getSmallPlayers().containsKey(name.toLowerCase())) {
+        if (getMyHouse().getSmallPlayers().containsKey(name.toLowerCase())) {
             // update the corresponding small player.
-            smallp = myHouse.getSmallPlayers().get(name.toLowerCase());
+            smallp = getMyHouse().getSmallPlayers().get(name.toLowerCase());
         } else {
             smallp = new SmallPlayer(getExperience(), lastOnline, getRating(), getName(), getFluffText(), getMyHouse());
-            myHouse.getSmallPlayers().put(name.toLowerCase(), smallp);
+            getMyHouse().getSmallPlayers().put(name.toLowerCase(), smallp);
         }
 
         smallp.setLastOnline(lastOnline);
@@ -2672,16 +2413,12 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
         attackRestrictionUntil = l;
     }
 
-    public double getRating() {
-        return rating;
-    }
-
     public void setRating(double d) {
-        rating = d;
+        super.setRating(d);
 
         // update the corresponding small player.
-        SmallPlayer smallp = myHouse.getSmallPlayers().get(name.toLowerCase());
-        smallp.setRating(rating);
+        SmallPlayer smallp = getMyHouse().getSmallPlayers().get(name.toLowerCase());
+        smallp.setRating(getRating());
 
         // if sharing ratings, send to clients
         if (!Boolean.parseBoolean(getMyHouse().getConfig("HideELO"))) {
@@ -2704,7 +2441,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
         fluffText = s;
 
         // update the corresponding small player.
-        SmallPlayer smallp = myHouse.getSmallPlayers().get(name.toLowerCase());
+        SmallPlayer smallp = getMyHouse().getSmallPlayers().get(name.toLowerCase());
         smallp.setFluffText(fluffText);
 
         setSave();
@@ -2727,9 +2464,9 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
 
     public int getAmountOfTimesUnitExistsInArmies(int unitID) {
         int result = 0;
-        Vector<SArmy> v = getArmies();
+        List<SArmy> v = getArmies();
         for (int i = 0; i < v.size(); i++) {
-            SArmy a = v.elementAt(i);
+            SArmy a = v.get(i);
             if (a.getUnit(unitID) != null) {
                 result++;
             }
@@ -2747,40 +2484,6 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
         }
     }// end checkAndUpdateArmies
 
-    // INFLUENCE SET/ADD/GET METHODS @urgru 1/30/03
-    /**
-     * A method which returns a players influence
-     *
-     * @return int - influence amount
-     */
-    public int getInfluence() {
-        return influence;
-    }
-
-    /**
-     * A method which directly sets the amount of influence a player has
-     *
-     * @param i
-     *            - value to give influence
-     */
-    public void setInfluence(int i) {
-        influence = i;
-        if (influence > Integer.parseInt(getMyHouse().getConfig("InfluenceCeiling"))) {
-            influence = (Integer.parseInt(getMyHouse().getConfig("InfluenceCeiling")));// set
-            // to
-            // ceiling
-            // if
-            // above
-        }
-
-        if (influence < 0) {
-            influence = 0; // Set to 0 if below
-        }
-
-        CampaignMain.cm.toUser("PL|SI|" + influence, name, false);
-        setSave();
-    }
-
     public int getGroupAllowance() {
         return groupAllowance;
     }
@@ -2789,28 +2492,17 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
         groupAllowance = i;
     }
 
-    // get current amount of reward points a player has
-    public int getReward() {
-        return rewardPoints;
-    }
-
     // set the current amount of reward points a player has.
-    public void setReward(int i) {
-        rewardPoints = i;
-        if (rewardPoints > (Integer.parseInt(getMyHouse().getConfig("XPRewardCap")))) {
-            rewardPoints = (Integer.parseInt(getMyHouse().getConfig("XPRewardCap")));
-        }
-
-        if (rewardPoints < 0) {
-            rewardPoints = 0;
-        }
-
+    public void setRewardPoints(int rewardPoints) {
+        super.setRewardPoints(rewardPoints);
         CampaignMain.cm.toUser("PL|SRP|" + rewardPoints, name, false);
         setSave();
     }
 
-    public void addReward(int toAdd) {
-        setReward(getReward() + toAdd);
+    public void setInfluence(int influence) {
+        super.setInfluence(influence);
+        CampaignMain.cm.toUser("PL|SI|" + getInfluence(), name, false);
+        setSave();
     }
 
     // sets counter to next RP injection triggered by XP gains.
@@ -3000,7 +2692,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
             }// end for type
         }
 
-        for (SUnit unit : units) {
+        for (SUnit unit : getUnits()) {
             Pilot pilot = unit.getPilot();
 
             if (pilot.getHits() <= 0) {
@@ -3045,7 +2737,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
                 }// end for weight
             }// end for type
         } else {
-            for (SUnit unit : units) {
+            for (SUnit unit : getUnits()) {
                 Pilot pilot = unit.getPilot();
 
                 if (pilot.getHits() <= 0) {
@@ -3076,7 +2768,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
      */
     public String getReadableStatus(boolean adminStatus) {
         DecimalFormat myFormatter = new DecimalFormat("####.##");
-        StringBuilder s = new StringBuilder("<br><b>Status for: " + getColoredName() + " (" + myHouse.getColoredName());
+        StringBuilder s = new StringBuilder("<br><b>Status for: " + getColoredName() + " (" + getMyHouse().getColoredName());
 
         if (getSubFactionName().trim().length() > 0) {
             s.append("::");
@@ -3101,12 +2793,12 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
             }
         }
 
-        s.append("  " + CampaignMain.cm.moneyOrFluMessage(true, false, getMoney()) + " //  " + CampaignMain.cm.moneyOrFluMessage(false, false, influence) + " // " + experience + " Experience<br>");
+        s.append("  " + CampaignMain.cm.moneyOrFluMessage(true, false, getMoney()) + " //  " + CampaignMain.cm.moneyOrFluMessage(false, false, getInfluence()) + " // " + experience + " Experience<br>");
 
         // advanced repair
         if (CampaignMain.cm.isUsingAdvanceRepair()) {
-            s.append("Technicians (Green/Reg/Vet/Elite): " + getTotalTechs().elementAt(UnitUtils.TECH_GREEN) + "/" + getTotalTechs().elementAt(UnitUtils.TECH_REG) + "/" + getTotalTechs().elementAt(UnitUtils.TECH_VET) + "/" + getTotalTechs().elementAt(UnitUtils.TECH_ELITE) + "<br>");
-            s.append("Idle Techs (Green/Reg/Vet/Elite):  " + getAvailableTechs().elementAt(UnitUtils.TECH_GREEN) + "/" + getAvailableTechs().elementAt(UnitUtils.TECH_REG) + "/" + getAvailableTechs().elementAt(UnitUtils.TECH_VET) + "/" + getAvailableTechs().elementAt(UnitUtils.TECH_ELITE) + "<br>");
+            s.append("Technicians (Green/Reg/Vet/Elite): " + getTotalTechs().get(UnitUtils.TECH_GREEN) + "/" + getTotalTechs().get(UnitUtils.TECH_REG) + "/" + getTotalTechs().get(UnitUtils.TECH_VET) + "/" + getTotalTechs().get(UnitUtils.TECH_ELITE) + "<br>");
+            s.append("Idle Techs (Green/Reg/Vet/Elite):  " + getAvailableTechs().get(UnitUtils.TECH_GREEN) + "/" + getAvailableTechs().get(UnitUtils.TECH_REG) + "/" + getAvailableTechs().get(UnitUtils.TECH_VET) + "/" + getAvailableTechs().get(UnitUtils.TECH_ELITE) + "<br>");
             s.append("Bays: " + getFreeBays() + "/" + getTotalMekBays() + "<br>");
             s.append("Leased Bays: " + getBaysOwned() + " (Cost: " + CampaignMain.cm.moneyOrFluMessage(true, false, getCurrentTechPayment()) + "/Game)<br>");
         }
@@ -3133,11 +2825,11 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
             s.append("Rating: " + myFormatter.format(getRating()) + "<br>");
         }
         if (Boolean.parseBoolean(getMyHouse().getConfig("ShowReward"))) {
-            s.append("Current " + CampaignMain.cm.getConfig("RPLongName") + ": " + getReward() + " (Maximum  of " + Integer.parseInt(getMyHouse().getConfig("XPRewardCap")) + ")<br>");
+            s.append("Current " + CampaignMain.cm.getConfig("RPLongName") + ": " + getRewardPoints() + " (Maximum  of " + Integer.parseInt(getMyHouse().getConfig("XPRewardCap")) + ")<br>");
         }
 
         // if merc show their status.
-        if (myHouse.isMercHouse()) {
+        if (getMyHouse().isMercHouse()) {
             s.append("<br>" + getReadableMercStatus());
         }
 
@@ -3190,7 +2882,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
         }
 
         s.append("<br><b>Contents of Hangar:</b><br>");
-        for (SUnit currU : units) {
+        for (SUnit currU : getUnits()) {
 
             if (currU.getStatus() == Unit.STATUS_FORSALE) {
                 continue;
@@ -3205,8 +2897,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
 
         // Get info for units the player is selling on Market2
         StringBuilder saleUnits = new StringBuilder();
-        for (SUnit currU : units) {
-
+        for (SUnit currU : getUnits()) {
             if (currU.getStatus() != Unit.STATUS_FORSALE) {
                 continue;
             }
@@ -3242,12 +2933,12 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
      */
     public String getReadableMercStatus() {
         String s = "";
-        if (myHouse.isMercHouse()) {// if a merc
+        if (getMyHouse().isMercHouse()) {// if a merc
             s = "Mercenary information for " + getName() + ": <br>";// list name
-            s += "Currently fighting for: " + (((MercHouse) myHouse).getHouseFightingFor(this)).getName() + "<br>";// list
+            s += "Currently fighting for: " + (((MercHouse) getMyHouse()).getHouseFightingFor(this)).getName() + "<br>";// list
             // employing
             // faction
-            ContractInfo contract = (((MercHouse) myHouse).getContractInfo(this));
+            ContractInfo contract = (((MercHouse) getMyHouse()).getContractInfo(this));
             if (contract != null) {
                 s += contract.getInfo(this);
             } else {
@@ -3271,18 +2962,18 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
         result.append(name);
         result.append(money);
         result.append(experience);
-        result.append(units.size());
-        if (units.size() > 0) {
-            synchronized (units) {
-                for (SUnit currU : units) {
-                    currU.getPilot().setCurrentFaction(myHouse.getName());
+        result.append(getUnits().size());
+        if (getUnits().size() > 0) {
+            synchronized (getUnits()) {
+                for (SUnit currU : getUnits()) {
+                    currU.getPilot().setCurrentFaction(getMyHouse().getName());
                     result.append(currU.toString(toClient));
                 }
             }
         }
         result.append(armies.size());
         for (int i = 0; i < armies.size(); i++) {
-            result.append(armies.elementAt(i).toString(toClient, "%"));
+            result.append(armies.get(i).toString(toClient, "%"));
         }
         if (!toClient) {
             if (getMyHouse() != null) {
@@ -3303,9 +2994,9 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
                 result.append(getRatingRounded());
             }
         } else {
-            result.append(rating);
+            result.append(getRating());
         }
-        result.append(influence);
+        result.append(getInfluence());
         if (!toClient) {
             result.append(fluffText + " ");
             /*
@@ -3326,7 +3017,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
             result.append(technicians);// used when saving to houses.dat
         }
         // above is used when sending to client bad hack but needed for now
-        result.append(rewardPoints); // saving current reward points
+        result.append(getRewardPoints()); // saving current reward points
         /*
          * In older code, player's price modifier (mezzo) was saved here. This
          * feature has been eliminated, and the spaces can be reclaimed. @urgru
@@ -3339,11 +3030,11 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
 
         result.append(getMekToken());
 
-        result.append(myHouse.getName() + " ");
+        result.append(getMyHouse().getName() + " ");
         if (toClient) {
             result.append(getHouseFightingFor().getName() + " ");
             if (getMyLogo().length() == 0) {
-                result.append(myHouse.getLogo() + " ");
+                result.append(getMyHouse().getLogo() + " ");
             } else {
                 result.append(getMyLogo() + " ");
             }
@@ -3364,7 +3055,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
                 result.append(technicians);
             }
             if (getMyLogo().trim().length() == 0) {
-                result.append(myHouse.getLogo() + " ");
+                result.append(getMyHouse().getLogo() + " ");
             } else {
                 result.append(getMyLogo() + " ");
             }
@@ -3443,12 +3134,12 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
 
             int numofarmies = 0;
             int numofUnits = TokenReader.readInt(ST);
-            units = new Vector<SUnit>(1, 1);
+            clearUnits();
 
             for (int i = 0; i < numofUnits; i++) {
                 SUnit m = new SUnit();
                 m.fromString((String) ST.nextElement());
-                units.add(m);
+                addUnit(m);
                 CampaignMain.cm.toUser("PL|HD|" + m.toString(true), name, false);
             }
 
@@ -3472,8 +3163,8 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
             TokenReader.readString(ST);// Number of Bays
             TokenReader.readString(ST);// Number of Free Bays
 
-            rating = TokenReader.readDouble(ST);
-            influence = TokenReader.readInt(ST);
+            super.setRating(TokenReader.readDouble(ST));
+            super.setInfluence(TokenReader.readInt(ST));
 
             fluffText = TokenReader.readString(ST).trim();
 
@@ -3495,17 +3186,17 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
                 technicians = (mt != -1) ? Math.min(te, mt) : te;
             }
 
-            rewardPoints = TokenReader.readInt(ST);
+            setRewardPoints(TokenReader.readInt(ST));
 
             //@salient reclaimed token for mini campaign data
             loadStatusMC(TokenReader.readString(ST));
 
             setMekToken(TokenReader.readInt(ST));
 
-            myHouse = CampaignMain.cm.getHouseFromPartialString(TokenReader.readString(ST));
+            setMyHouse(CampaignData.cd.getHouseByName(TokenReader.readString(ST)));
 
-            if (myHouse == null) {
-                myHouse = CampaignMain.cm.getHouseFromPartialString(CampaignMain.cm.getConfig("NewbieHouseName"));
+            if (getMyHouse() == null) {
+                setMyHouse(CampaignData.cd.getHouseByName(CampaignData.cd.getCampaignOptions().getConfig("NewbieHouseName")));
             }
 
             setXpTillReward(TokenReader.readInt(ST));
@@ -3557,7 +3248,6 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
             // this will allow them to
             // Still Load.
             try {
-
                 setLastAttackFromReserve(TokenReader.readLong(ST));
                 setGroupAllowance(TokenReader.readInt(ST));
                 setLastISP(TokenReader.readString(ST));
@@ -3637,12 +3327,12 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
             /*
              * Check all units for bad ammo or illegal/mis-set vacant pilots.
              * This was being done at the same time as the units are unstrung,
-             * but caused a null b/c fixAmmo() uses .myHouse(), which is null at
+             * but caused a null b/c fixAmmo() uses .getMyHouse()(), which is null at
              * that point in the unstring. If the units are changed as a result
              * of the checks, a PL|UU is sent, as well as a PL|SAD for each army
              * that includes the unit.
              */
-            for (SUnit currU : units) {
+            for (SUnit currU : getUnits()) {
                 fixPilot(currU);
             }
         } catch (Exception ex) {
@@ -3659,7 +3349,6 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
      * @param unit
      */
     private void fixPilot(SUnit unit) {
-
         if (!unit.hasVacantPilot()) {
             return;
         }
@@ -3685,7 +3374,6 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
                 // operations
             }
         }
-
     }
 
     public UnitComponents getUnitParts() {
@@ -3716,7 +3404,6 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
             getUnitParts().add(part, amount);
         }
         CampaignMain.cm.toUser("PL|UPPC|" + part + "#" + amount, getName(), false);
-
     }
 
     public SArmy getLockedArmy() {
@@ -3728,23 +3415,6 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
         }
 
         return null;
-    }
-
-    public int getDBId() {
-        return DBId;
-    }
-
-    public void setDBId(int id) {
-        DBId = id;
-        personalPilotQueue.setOwnerID(id);
-    }
-
-    public void setForumID(int id) {
-        forumID = id;
-    }
-
-    public int getForumID() {
-        return forumID;
     }
 
     @Override
@@ -3762,7 +3432,6 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     }
 
     public SubFaction getSubFaction() {
-
         SubFaction sub = getMyHouse().getSubFactionList().get(subFaction);
 
         if (sub == null) {
@@ -3792,13 +3461,11 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     }
 
     public boolean canBePromoted() {
-
         if (getMyHouse().getSubFactionList().size() < 1) {
             return false;
         }
 
         int days = getMyHouse().getIntegerConfig("daysbetweenpromotions");
-
         long day = 1000 * 60 * 60 * 24;
 
         try {
@@ -3813,37 +3480,28 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
             LOGGER.error("Exception: ", ex);
             return false;
         }
-
         return true;
-
     }
 
     public void checkForPromotion() {
-
-    	if(CampaignMain.cm.getBooleanConfig("Disable_Promote_Subfaction")) //@salient
-    	{
+    	if(CampaignMain.cm.getBooleanConfig("Disable_Promote_Subfaction")) { //@salient
     		return;
     	}
 
         if (!canBePromoted()) {
             return;
         }
-
         int currentAccessLevel = getSubFactionAccess();
 
         for (SubFaction subFaction : getMyHouse().getSubFactionList().values()) {
-
             if ((currentAccessLevel < Integer.parseInt(subFaction.getConfig("AccessLevel"))) && (getRating() >= Integer.parseInt(subFaction.getConfig("MinELO"))) && (getExperience() >= Integer.parseInt(subFaction.getConfig("MinExp")))) {
                 CampaignMain.cm.toUser("You are eligible for a promotion to subFaction " + subFaction.getConfig("Name") + ". <a href=\"MEKWARS/c RequestSubFactionPromotion#" + subFaction.getConfig("Name") + "\">Click here to request promotion.</a>", getName());
             }
-
         }
     }
 
     public void checkForDemotion() {
-
-    	if(CampaignMain.cm.getBooleanConfig("Disable_Demote_Subfaction")) //@salient
-    	{
+    	if(CampaignMain.cm.getBooleanConfig("Disable_Demote_Subfaction")) { //@salient
     		return;
     	}
 
@@ -3983,45 +3641,9 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
             // Unlimited
             return true;
         }
-
         int inHangar = countUnits(uType, uWeightClass);
 
-        if (inHangar < limit) {
-            return true;
-        }
-
-        if ((inHangar >= limit)  && Boolean.parseBoolean(getMyHouse().getConfig("UseSlidingHangarLimits")) ) {
-        	return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * A method to count the units of a given type and weight in a player's
-     * hangar
-     *
-     * @param uType
-     * @param uWeightClass
-     * @return number of units
-     */
-    public int countUnits(int uType, int uWeightClass) {
-        if ((uType < 0) || (uType > Unit.AERO)) {
-            LOGGER.error("Invalid uType in SPlayer.countUnits: " + uType);
-            return 0;
-        }
-        if ((uWeightClass < 0) || (uWeightClass > Unit.ASSAULT)) {
-            LOGGER.error("Invalid uWeightClass in SPlayer.countUnits: " + uWeightClass);
-            return 0;
-        }
-        // Actually count them now
-        int count = 0;
-        for (SUnit u : units) {
-            if (!u.isChristmasUnit() && (u.getType() == uType) && (u.getWeightclass() == uWeightClass)) {
-                count++;
-            }
-        }
-        return count;
+        return (inHangar < limit) || ((inHangar >= limit) && Boolean.parseBoolean(getMyHouse().getConfig("UseSlidingHangarLimits")));
     }
 
     /**
@@ -4048,30 +3670,22 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
      *
      * @return true if at all limits, false otherwise
      */
-    public boolean isAtUnitLimits()
-    {
+    public boolean isAtUnitLimits() {
     	boolean result = false;
-
     	boolean dontCountAero = CampaignMain.cm.getBooleanConfig("IgnoreAeroUnitLimit");
-
     	int uType = Unit.AERO;
 
-    	if (dontCountAero)
+    	if (dontCountAero) {
     		uType = Unit.BATTLEARMOR;
+        }
 
-        for (int t = Unit.MEK; t <= uType; t++)
-        {
-            for (int w = Unit.LIGHT; w <= Unit.ASSAULT; w++)
-            {
+        for (int t = Unit.MEK; t <= uType; t++) {
+            for (int w = Unit.LIGHT; w <= Unit.ASSAULT; w++) {
                 int limit = CampaignData.cd.getCampaignOptions().getUnitLimit(t, w);
                 int inHangar = countUnits(t, w);
 
-                if(limit != -1)
-                {
-                	if (inHangar == limit)
-                		result = true;
-                	else
-                		return false;
+                if(limit != -1) {
+                    return inHangar == limit;
                 }
             }
         }
@@ -4084,30 +3698,22 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
      *
      * @return true if at or over all limits, false otherwise
      */
-    public boolean isAtOrOverUnitLimits()
-    {
+    public boolean isAtOrOverUnitLimits() {
     	boolean result = false;
-
-    	boolean dontCountAero = CampaignMain.cm.getBooleanConfig("IgnoreAeroUnitLimit");
-
+    	boolean dontCountAero = CampaignData.cd.getCampaignOptions().getBooleanConfig("IgnoreAeroUnitLimit");
     	int uType = Unit.AERO;
 
-    	if (dontCountAero)
+    	if (dontCountAero) {
     		uType = Unit.BATTLEARMOR;
+        }
 
-        for (int t = Unit.MEK; t <= uType; t++)
-        {
-            for (int w = Unit.LIGHT; w <= Unit.ASSAULT; w++)
-            {
+        for (int t = Unit.MEK; t <= uType; t++) {
+            for (int w = Unit.LIGHT; w <= Unit.ASSAULT; w++) {
                 int limit = CampaignData.cd.getCampaignOptions().getUnitLimit(t, w);
                 int inHangar = countUnits(t, w);
 
-                if(limit != -1)
-                {
-                	if (inHangar >= limit)
-                		result = true;
-                	else
-                		return false;
+                if(limit != -1) {
+                    return inHangar >= limit;
                 }
             }
         }
@@ -4144,35 +3750,6 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     }
 
     /**
-     * A method to determine if the player is over the unit limit
-     * and the server is configured to use sliding hangar cost
-     * increases
-     *
-     *
-     */
-    public boolean hasHangarPenalty(int uType, int uWeight) {
-    	// Always false if we're not using the sliding limits
-    	if (!Boolean.parseBoolean(getMyHouse().getConfig("UseSlidingHangarLimits"))) {
-    		return false;
-    	}
-
-        int limit = CampaignData.cd.getCampaignOptions().getUnitLimit(uType, uWeight);
-
-    	// Always false if the particular limit is not checked
-    	if (limit < 0) {
-    		return false;
-    	}
-
-    	int numUnits = countUnits(uType, uWeight);
-    	// False if we're below the limit
-    	if (limit >= numUnits) {
-    		return false;
-    	}
-
-    	return true;
-    }
-
-    /**
      * Calculates and returns the string to be sent to the client to
      * set both the maintenance penalty and the purchase price penalty
      * for each unit type and weight.
@@ -4196,7 +3773,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
     public int calculateHangarPenaltyForNextPurchase(int type, int weight) {
     	int penalty = 0;
 
-        int limit = CampaignData.cd.getCampaignOptions().getUnitLimit(type, weight);
+		int limit = CampaignData.cd.getCampaignOptions().getUnitLimit(type, weight);
 		int numUnits = countUnits(type, weight) + 1;
 
 		if ((limit == -1) || (numUnits <= limit)) {
@@ -4206,47 +3783,12 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
 		int penaltyUnits = numUnits - limit;
 
 		penalty = (int)(Math.pow(penaltyUnits, Double.parseDouble(getMyHouse().getConfig("SlidingHangarLimitModifier"))));
-
-
     	return penalty;
     }
 
-	public int calculateHangarPenalty(int type_id, int weightclass) {
-		if(!hasHangarPenalty(type_id, weightclass)) {
-			return 0;
-		}
-		int penalty = 0;
-
-        int limit = CampaignData.cd.getCampaignOptions().getUnitLimit(type_id, weightclass);
-		int numUnits = countUnits(type_id, weightclass);
-
-		if (numUnits <= limit) {
-			return 0;
-		}
-
-		int penaltyUnits = numUnits - limit;
-
-		penalty = (int)(Math.pow(penaltyUnits, Double.parseDouble(getMyHouse().getConfig("SlidingHangarLimitModifier"))));
-
-		return penalty;
-	}
-
-	public int calculateTotalHangarPenalty() {
-		int penalty = 0;
-		for (int type = Unit.MEK; type < Unit.MAXBUILD; type++) {
-			for (int weight = Unit.LIGHT; weight <= Unit.ASSAULT; weight++) {
-				penalty += calculateHangarPenalty(type, weight);
-			}
-		}
-		return penalty;
-	}
-
 	//@salient
-	public boolean hasUnusedMekTokens()
-	{
-
-		if( getMekToken() < Integer.parseInt(getMyHouse().getConfig("FreeBuild_Limit")) )
-		{
+	public boolean hasUnusedMekTokens() {
+		if (getMekToken() < Integer.parseInt(getMyHouse().getConfig("FreeBuild_Limit"))) {
 			return true;
 		}
 
@@ -4254,8 +3796,7 @@ public final class SPlayer extends Player implements Comparable<Object>, IBuyer,
 	}
 
 	//@salient send msg to self
-	public void toSelf(String msg)
-	{
+	public void toSelf(String msg) {
 		CampaignMain.cm.toUser(msg, getName(), true);
 	}
-}// end SPlayer()
+}

--- a/MekWarsServer/src/mekwars/server/campaign/SPlayer.java
+++ b/MekWarsServer/src/mekwars/server/campaign/SPlayer.java
@@ -350,27 +350,20 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
     }
 
     /**
-     * Remove the Unit with ID unitid from the player. Ops are checked by
+     * Remove the Unit with ID unitId from the player. Ops are checked by
      * discrete commands (ie - SellUnit), unchecked by large blocks of code
      * which force a check on their own (ie - ShortResolver).
      *
-     * @param unitid
+     * @param unitId
      *            the ID of the unit to remove
      */
-    public void removeUnit(int unitid, boolean sendArmyUpdate) {
+    public void removeUnit(int unitId, boolean sendArmyUpdate) {
         SUnit Mech = null;
-        synchronized (getUnits()) {
-        	for (int i = 0; i < getUnits().size(); i++) {
-        		Mech = getUnits().get(i);
-        		if (Mech.getId() == unitid) {
-        			getUnits().remove(i);
-        		}
-            }
-        }
 
+        super.removeUnit(unitId);
         for (SArmy currA : getArmies()) {
-            if (currA.getUnitPosition(unitid) > -1) {
-                currA.removeUnit(unitid);
+            if (currA.getUnitPosition(unitId) > -1) {
+                currA.removeUnit(unitId);
                 if (sendArmyUpdate) {
                     CampaignMain.cm.toUser("PL|SAD|" + currA.toString(true, "%"), name, false);
                     CampaignMain.cm.getOpsManager().checkOperations(currA, true);// update
@@ -380,7 +373,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
             }
         }// end for(all armies)
 
-        CampaignMain.cm.toUser("PL|RU|" + unitid, name, false);
+        CampaignMain.cm.toUser("PL|RU|" + unitId, name, false);
         CampaignMain.cm.toUser("PL|SB|" + getTotalMekBays(), name, false);
         CampaignMain.cm.toUser("PL|SF|" + getFreeBays(), name, false);
         setSave();// save on remove (adminstrip, etc)

--- a/MekWarsServer/src/mekwars/server/campaign/commands/AcceptAttackFromReserveCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/AcceptAttackFromReserveCommand.java
@@ -214,7 +214,7 @@ public class  AcceptAttackFromReserveCommand  implements Command {
 			hasCost = true;
 		}
 		if (rp > 0) {
-			dp.addReward(-rp);
+			dp.addRewardPoints(-rp);
 			if(hasCost)
 				toSend += ", ";
 			else

--- a/MekWarsServer/src/mekwars/server/campaign/commands/ActivateCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/ActivateCommand.java
@@ -13,8 +13,8 @@
 package mekwars.server.campaign.commands;
 
 import java.util.Iterator;
+import java.util.List;
 import java.util.StringTokenizer;
-import java.util.Vector;
 
 import mekwars.common.Unit;
 import mekwars.common.campaign.operations.Operation;
@@ -303,8 +303,7 @@ public class  ActivateCommand  implements Command {
      * 
      * Separate method, instead of inline in process(), so this can be moved into SPlayer easily if other code needs to do engine checks.
      */
-    private boolean armiesContainEnginedUnit(Vector<SArmy> armies) {
-
+    private boolean armiesContainEnginedUnit(List<SArmy> armies) {
         // loop though all units in all armies
         for (SArmy army : armies) {
             Iterator<Unit> units = army.getUnits().iterator();
@@ -325,8 +324,7 @@ public class  ActivateCommand  implements Command {
      * 
      * Separate method, instead of inline in process(), so this can be moved into SPlayer easily if other code needs to do leglessness (sp?) checks.
      */
-    private boolean armiesContainLeggedUnit(Vector<SArmy> armies) {
-
+    private boolean armiesContainLeggedUnit(List<SArmy> armies) {
         // loop though all units in all armies
         for (SArmy army : armies) {
             Iterator<Unit> units = army.getUnits().iterator();
@@ -370,8 +368,7 @@ public class  ActivateCommand  implements Command {
      * 
      * Separate method, instead of inline in process(), so this can be moved into SPlayer easily if other code needs to do damaged unit checks.
      */
-    private boolean armiesDamagedUnits(Vector<SArmy> armies) {
-
+    private boolean armiesDamagedUnits(List<SArmy> armies) {
         // loop though all units in all armies
         for (SArmy army : armies) {
             Iterator<Unit> units = army.getUnits().iterator();
@@ -396,8 +393,7 @@ public class  ActivateCommand  implements Command {
      * This checks all the units in the army to see if they have partial ammo bins.
      * 
      */
-    private boolean armiesPartialAmmoBinUnits(Vector<SArmy> armies) {
-
+    private boolean armiesPartialAmmoBinUnits(List<SArmy> armies) {
         // loop though all units in all armies
         for (SArmy army : armies) {
             Iterator<Unit> units = army.getUnits().iterator();
@@ -419,7 +415,7 @@ public class  ActivateCommand  implements Command {
      * see if any units in armies are locked, if so return true.
      * 
      */
-    private boolean hasLockedUnitsInArmies(Vector<SArmy> armies) 
+    private boolean hasLockedUnitsInArmies(List<SArmy> armies) 
     {
         for (SArmy army : armies) 
         {
@@ -436,7 +432,7 @@ public class  ActivateCommand  implements Command {
         return false;
     }
 
-    private boolean hasCommanderlessUnits(Vector<SArmy> armies) {
+    private boolean hasCommanderlessUnits(List<SArmy> armies) {
         // start Baruk Khazad!  20151108a 
         Boolean result = false;  
         for (SArmy army : armies) {
@@ -448,10 +444,8 @@ public class  ActivateCommand  implements Command {
         // end Baruk Khazad!  20151108a 
     }
 
-    private int hasIllegalOpArmies(SPlayer player, Vector<SArmy> armies) {
-
+    private int hasIllegalOpArmies(SPlayer player, List<SArmy> armies) {
         for (SArmy army : armies) {
-
             boolean canAttack = false;
             boolean canDefend = false;
 
@@ -477,10 +471,8 @@ public class  ActivateCommand  implements Command {
         return -1;
     }
 
-    private int hasNoAttackOptions(SPlayer player, Vector<SArmy> armies) {
-
+    private int hasNoAttackOptions(SPlayer player, List<SArmy> armies) {
         for (SArmy army : armies) {
-
             boolean canAttack = false;
             boolean requireAttackCapable = CampaignMain.cm.getBooleanConfig("RequireAttackCapableArmiesForActivation");
 

--- a/MekWarsServer/src/mekwars/server/campaign/commands/BidCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/BidCommand.java
@@ -32,21 +32,21 @@ public class  BidCommand  implements Command {
 	public void setExecutionLevel(int i) {accessLevel = i;}
 	public String getSyntax() { return syntax;}
 	
-	public void process(StringTokenizer command,String Username) {
+	public void process(StringTokenizer command,String username) {
 		
 		//access check
 		if (accessLevel != 0) {
-			int userLevel = MWServ.getInstance().getUserLevel(Username);
+			int userLevel = MWServ.getInstance().getUserLevel(username);
 			if(userLevel < getExecutionLevel()) {
-				CampaignMain.cm.toUser("AM:Insufficient access level for command. Level: " + userLevel + ". Required: " + accessLevel + ".",Username,true);
+				CampaignMain.cm.toUser("AM:Insufficient access level for command. Level: " + userLevel + ". Required: " + accessLevel + ".",username,true);
 				return;
 			}
 		}
 
 		//load the SPlayer
-		SPlayer p = CampaignMain.cm.getPlayer(Username);
+		SPlayer p = CampaignMain.cm.getPlayer(username);
 		if (p == null) {
-			CampaignMain.cm.toUser("AM:Null SPlayer while bidding. Report immediately!",Username,true);
+			CampaignMain.cm.toUser("AM:Null SPlayer while bidding. Report immediately!",username,true);
 			return;
 		}
 		
@@ -57,27 +57,27 @@ public class  BidCommand  implements Command {
 			auctionID = Integer.parseInt(command.nextToken());
 			bidAmount = Integer.parseInt(command.nextToken());
 		} catch (Exception e) {
-			CampaignMain.cm.toUser("AM:Improper format. Try: /c bid#AuctionID#Amount",Username,true);
+			CampaignMain.cm.toUser("AM:Improper format. Try: /c bid#AuctionID#Amount",username,true);
 			return;
 		}
 		
 		//players whose factions don't have market buying access cannot bid
 		if (!p.getMyHouse().mayBuyFromBM()) {
-			CampaignMain.cm.toUser("AM:You are not allowed to buy units from the market. Your faction forbids it!", Username, true);
+			CampaignMain.cm.toUser("AM:You are not allowed to buy units from the market. Your faction forbids it!", username, true);
 			return;
 		}
 		
 		// check xp
 		int minBMEXP = CampaignMain.cm.getIntegerConfig("MinEXPforBMBuying");
 		if (p.getExperience() < minBMEXP) {
-			CampaignMain.cm.toUser("AM:You are not allowed to buy units from the Market. Required Experience: " + minBMEXP + ".", Username, true);
+			CampaignMain.cm.toUser("AM:You are not allowed to buy units from the Market. Required Experience: " + minBMEXP + ".", username, true);
 			return;
 		}
 		
 		//check the auction ID
 		MarketListing auction = CampaignMain.cm.getMarket().getListingByID(auctionID);
 		if (auction == null) {
-			CampaignMain.cm.toUser("AM:There is no auction with ID#" + auctionID + ".",Username,true);
+			CampaignMain.cm.toUser("AM:There is no auction with ID#" + auctionID + ".",username,true);
 			return;
 		}
 		
@@ -86,10 +86,10 @@ public class  BidCommand  implements Command {
 		if (bidAmount < minBid) {
 			if (!CampaignMain.cm.getBooleanConfig("HiddenBMUnits")) {
 				CampaignMain.cm.toUser("AM:Minimum bid for the " + auction.getListedModelName()
-					+ " is " + CampaignMain.cm.moneyOrFluMessage(true,false,minBid) + ". Nice try.",Username,true);
+					+ " is " + CampaignMain.cm.moneyOrFluMessage(true,false,minBid) + ". Nice try.",username,true);
 			} else {
 				CampaignMain.cm.toUser("AM:Minimum bid for the " + auction.getListedHiddenModelName()
-						+ " is " + CampaignMain.cm.moneyOrFluMessage(true,false,minBid) + ". Nice try.",Username,true);
+						+ " is " + CampaignMain.cm.moneyOrFluMessage(true,false,minBid) + ". Nice try.",username,true);
 			}
 			return;
 		}
@@ -97,35 +97,34 @@ public class  BidCommand  implements Command {
 		//check the player's flu
 		int bidFluCost = CampaignMain.cm.getIntegerConfig("BMBidFlu");
 		if (p.getInfluence() < bidFluCost) {
-			CampaignMain.cm.toUser("AM:You need " +CampaignMain.cm.moneyOrFluMessage(false,true,bidFluCost)+" to place a bid.", Username, true);
+			CampaignMain.cm.toUser("AM:You need " +CampaignMain.cm.moneyOrFluMessage(false,true,bidFluCost)+" to place a bid.", username, true);
 			return;
 		}
 		
 		// Check that the house is allowed to bid on this type of unit
 		int uType = auction.getUnitType();
 		int uWeight = auction.getUnitWeight();
-        boolean canBuy = CampaignData.cd.getCampaignOptions().canBuyFromBM(uType, uWeight);
-//		boolean canBuy = p.getMyHouse().canBuyFromBM(uType, uWeight);
+		boolean canBuy = CampaignData.cd.getCampaignOptions().canBuyFromBM(uType, uWeight);
 		if (!canBuy) {
 			CampaignMain.cm.toUser("AM:Your faction is not allowed to purchase " + 
 					Unit.getWeightClassDesc(uWeight) + " " + 
-					Unit.getTypeClassDesc(uType) + " from the Black Market.", Username, true);
+					Unit.getTypeClassDesc(uType) + " from the Black Market.", username, true);
 			return;
 		}
 		
 		/*
 		 * All checks cleared. Decrease the player's influence and add his bid.
 		 */
-		auction.placeBid(Username, bidAmount);
+		auction.placeBid(username, bidAmount);
 		p.addInfluence(-bidFluCost);
 		
 		CampaignMain.cm.toUser("AM:You bid "+CampaignMain.cm.moneyOrFluMessage(true,false,bidAmount)+" for the "
 				+ (CampaignMain.cm.getBooleanConfig("HiddenBMUnits") ? auction.getListedHiddenModelName() : auction.getListedModelName()) 
 				+ " (-" + CampaignMain.cm.moneyOrFluMessage(false,true,bidFluCost)
-				+").", Username, true);
+				+").", username, true);
 		
 		//send BM|CU to bidder
-		CampaignMain.cm.toUser("BM|CU|" + auction.toString(auctionID,p),Username,false);
+		CampaignMain.cm.toUser("BM|CU|" + auction.toString(auctionID,p),username,false);
 		
 	}//end process(string)
 }

--- a/MekWarsServer/src/mekwars/server/campaign/commands/CheckAttackCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/CheckAttackCommand.java
@@ -28,8 +28,7 @@ import mekwars.server.campaign.SPlayer;
 import mekwars.server.campaign.operations.OperationManager;
 import mekwars.server.campaign.operations.newopmanager.I_OperationManager;
 
-public class  CheckAttackCommand  implements Command {
-
+public class CheckAttackCommand implements Command {
 	int accessLevel = 0;
 	String syntax = "";
 	public int getExecutionLevel(){return accessLevel;}
@@ -138,9 +137,7 @@ public class  CheckAttackCommand  implements Command {
 		//otherwise, loop out *all* the armies
 		else {
 			Desc = "Intelligence reports the following attack options:<br>";
-			Enumeration<SArmy> e = p.getArmies().elements();
-			while (e.hasMoreElements()) {
-				SArmy arm = e.nextElement();
+            for (SArmy arm: p.getArmies()) {
 				Desc += "<table><tr><td>";
 				if (arm != null && !arm.isDisabled()) {
 					Desc += "Army " + arm.getID() ;

--- a/MekWarsServer/src/mekwars/server/campaign/commands/CreateArmyCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/CreateArmyCommand.java
@@ -58,13 +58,12 @@ public class  CreateArmyCommand  implements Command {
 		 * no army with a matching ID is found in the player's list. This
 		 * involves hideous nested loops, but works well.
 		 */
-		p.getArmies().trimToSize();
 		int i = 0;
 		boolean free = false;
 		while (!free) {
 			free = true;
 			for (int j = 0; j < p.getArmies().size(); j++) {
-				if (p.getArmies().elementAt(j).getID() == i) {
+				if (p.getArmies().get(j).getID() == i) {
 					free = false;
 					i++;
 				}

--- a/MekWarsServer/src/mekwars/server/campaign/commands/DefectCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/DefectCommand.java
@@ -201,7 +201,7 @@ public class  DefectCommand  implements Command {
             int oldExp = p.getExperience();
             int oldMoney = p.getMoney();
             int oldFlu = p.getInfluence();
-            int oldRP = p.getReward();
+            int oldRP = p.getRewardPoints();
 
             int newExp = 0;
             int newMoney = 0;
@@ -477,7 +477,7 @@ public class  DefectCommand  implements Command {
                     p.addMoney(-mnyLoss);// pos number for string setup.
                     // negate to reduce.
                     p.setInfluence(newFlu);
-                    p.setReward(newRP);
+                    p.setRewardPoints(newRP);
 
                     // have string show those losses
                     toReturn += "You've lost " + penString;

--- a/MekWarsServer/src/mekwars/server/campaign/commands/DefectCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/DefectCommand.java
@@ -576,8 +576,8 @@ public class  DefectCommand  implements Command {
             MWServ.getInstance().addToNewsFeed("Player Defection", "Player News", Username + " defected from " + oldHouse.getName() + " to " + HouseName);
             MWServ.getInstance().postToDiscord(Username + " defected from " + oldHouse.getName() + " to " + HouseName);
 
-            if ( p.getMyLogo().trim().equals(oldHouse.getLogo().trim()) ){
-                p.setMyLogo(newHouse.getLogo().trim());
+            if ( p.getLogo().trim().equals(oldHouse.getLogo().trim()) ){
+                p.setLogo(newHouse.getLogo().trim());
             }
             
             // for now, move defecting players back to standard-user access.

--- a/MekWarsServer/src/mekwars/server/campaign/commands/DefendCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/DefendCommand.java
@@ -285,7 +285,7 @@ public class  DefendCommand  implements Command {
             hasCost = true;
         }
         if (rp > 0) {
-            dp.addReward(-rp);
+            dp.addRewardPoints(-rp);
             if (hasCost)
                 toSend += ", ";
             else

--- a/MekWarsServer/src/mekwars/server/campaign/commands/EnrollCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/EnrollCommand.java
@@ -144,7 +144,7 @@ public class  EnrollCommand  implements Command {
 
 		String unitInfo = nh.getNewSOLUnits(newPlayer,null);
 		newPlayer.addMoney(CampaignMain.cm.getIntegerConfig("PlayerBaseMoney"));
-		newPlayer.addReward(CampaignMain.cm.getIntegerConfig("PlayerBaseRP"));  //@Salient adding option to give new player RP
+		newPlayer.addRewardPoints(CampaignMain.cm.getIntegerConfig("PlayerBaseRP"));  //@Salient adding option to give new player RP
 		newPlayer.addInfluence(CampaignMain.cm.getIntegerConfig("PlayerBaseFlu")); //@Salient adding option to give new player Flu
 
 		String result = new String("AM:<font color=\"navy\">WELCOME TO MEKWARS!</font>"

--- a/MekWarsServer/src/mekwars/server/campaign/commands/ExchangePilotInUnitCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/ExchangePilotInUnitCommand.java
@@ -126,9 +126,7 @@ public class ExchangePilotInUnitCommand implements Command {
                 //CampaignMain.cm.toUser("PL|PPQ|"+p.getPersonalPilotQueue().toString(true),Username,false);
 				CampaignMain.cm.toUser("PL|UU|"+m.getId()+"|"+m.toString(true),Username,false);
 				
-				Enumeration<SArmy> f = p.getArmies().elements();
-				while (f.hasMoreElements()) {
-					SArmy currArmy = f.nextElement();
+                for (SArmy currArmy : p.getArmies()) {
 					if (currArmy.getUnit(m.getId()) != null) {
 						currArmy.setBV(0);//not null so recalc BV of the army
 						CampaignMain.cm.toUser("PL|SAD|"+currArmy.toString(true,"%"),Username,false);

--- a/MekWarsServer/src/mekwars/server/campaign/commands/FireTechsCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/FireTechsCommand.java
@@ -131,8 +131,8 @@ public class  FireTechsCommand  implements Command {
         if ( command.hasMoreElements())
             techType = Integer.parseInt(command.nextToken());
         
-        int totalTechsToFire = player.getTotalTechs().get(techType);
-        int availableTechsToFire = player.getAvailableTechs().get(techType);
+        int totalTechsToFire = player.getTotalTech(techType);
+        int availableTechsToFire = player.getAvailableTech(techType);
         
         if ( totalTechsToFire < numberOfTechs ){
             CampaignMain.cm.toUser("AM:You do not have enough "+UnitUtils.techDescription(techType)+" techs to fire! You only have "+totalTechsToFire+".",Username,true);

--- a/MekWarsServer/src/mekwars/server/campaign/commands/FireTechsCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/FireTechsCommand.java
@@ -131,8 +131,8 @@ public class  FireTechsCommand  implements Command {
         if ( command.hasMoreElements())
             techType = Integer.parseInt(command.nextToken());
         
-        int totalTechsToFire = player.getTotalTechs().elementAt(techType);
-        int availableTechsToFire = player.getAvailableTechs().elementAt(techType);
+        int totalTechsToFire = player.getTotalTechs().get(techType);
+        int availableTechsToFire = player.getAvailableTechs().get(techType);
         
         if ( totalTechsToFire < numberOfTechs ){
             CampaignMain.cm.toUser("AM:You do not have enough "+UnitUtils.techDescription(techType)+" techs to fire! You only have "+totalTechsToFire+".",Username,true);

--- a/MekWarsServer/src/mekwars/server/campaign/commands/FreeBuildCreateUnitCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/FreeBuildCreateUnitCommand.java
@@ -229,9 +229,8 @@ public class FreeBuildCreateUnitCommand implements Command {
 			}
 		}
 		
-		if(!allowDupes)
-		{
-			Vector<SUnit> playersUnits = player.getUnits();
+		if (!allowDupes) {
+			List<SUnit> playersUnits = player.getUnits();
 			
 			for(SUnit aUnit : playersUnits)
 			{
@@ -243,9 +242,8 @@ public class FreeBuildCreateUnitCommand implements Command {
 			}			
 		}
 		
-		if(useDupeLimits)
-		{
-			Vector<SUnit> playersUnits = player.getUnits();
+		if (useDupeLimits) {
+			List<SUnit> playersUnits = player.getUnits();
 			int unitCount = 0;
 			
 			for(SUnit aUnit : playersUnits)

--- a/MekWarsServer/src/mekwars/server/campaign/commands/NoPlayCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/NoPlayCommand.java
@@ -101,7 +101,7 @@ public class  NoPlayCommand  implements Command {
         boolean hasEnoughRP = false;
         boolean hasEnoughInfluence = false;
         boolean hasEnoughMU = false;
-        if (p.getReward() >= removeRPCost) {
+        if (p.getRewardPoints() >= removeRPCost) {
             hasEnoughRP = true;
         }
         if (p.getMoney() >= removeMUCost) {
@@ -261,7 +261,7 @@ public class  NoPlayCommand  implements Command {
                     exList.removeExclude(false, excludeName);
                     CampaignMain.cm.toUser(excludeName + "was removed from your no-play list (-" + shortCost + ").", Username, true);
                     p.addMoney(-removeMUCost);
-                    p.addReward(-removeRPCost);
+                    p.addRewardPoints(-removeRPCost);
                     p.addInfluence(-removeFluCost);
                     CampaignMain.cm.toUser("PL|PEU|" + p.getExclusionList().playerExcludeToString("$"), Username, false);
                     p.setSave();

--- a/MekWarsServer/src/mekwars/server/campaign/commands/RefreshFactoryCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/RefreshFactoryCommand.java
@@ -87,7 +87,7 @@ public class  RefreshFactoryCommand  implements Command {
 
 		int rpCost = CampaignMain.cm.getIntegerConfig("RewardPointToRefreshFactory");
 		int fluCost = CampaignMain.cm.getIntegerConfig("FluToRefreshFactory");
-		int playerRP = player.getReward();
+		int playerRP = player.getRewardPoints();
 		int playerFlu = player.getInfluence();
 
 		if (playerRP < rpCost && !useFlu)
@@ -103,7 +103,7 @@ public class  RefreshFactoryCommand  implements Command {
 		}
 
 		if(!useFlu)
-			player.addReward(-rpCost);
+			player.addRewardPoints(-rpCost);
 		else
 			player.addInfluence(-fluCost);
 

--- a/MekWarsServer/src/mekwars/server/campaign/commands/RepairUnitCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/RepairUnitCommand.java
@@ -109,7 +109,7 @@ public class RepairUnitCommand implements Command {
             if (MWServ.getInstance().getRTT().isBeingRepaired(unitID, location, slot, armor)) {
                 CampaignMain.cm.toUser(
                         "FSM|That section is already being repaired wait for the work to finish"
-                            + " before starting again.",
+                                + " before starting again.",
                         username,
                         false);
                 return;
@@ -133,12 +133,12 @@ public class RepairUnitCommand implements Command {
                 return;
             }
 
-            if (techType == UnitUtils.TECH_REWARD_POINTS && cost > player.getReward()) {
+            if (techType == UnitUtils.TECH_REWARD_POINTS && cost > player.getRewardPoints()) {
                 CampaignMain.cm.toUser(
                         "FSM|You do not have enough "
                                 + CampaignMain.cm.getConfig("RPLongName")
                                 + " to repair this location.",
-                        username,
+                        Username,
                         false);
                 return;
             }
@@ -155,7 +155,7 @@ public class RepairUnitCommand implements Command {
             int numberOfTechs = 1;
 
             if (techType < UnitUtils.TECH_PILOT) {
-                numberOfTechs = player.getAvailableTechs().elementAt(techType);
+                numberOfTechs = player.getAvailableTechs().get(techType);
             }
 
             if (techType == UnitUtils.TECH_PILOT
@@ -341,18 +341,18 @@ public class RepairUnitCommand implements Command {
             if (MWServ.getInstance().getRTT().getState() == Thread.State.TERMINATED) {
                 CampaignMain.cm.toUser(
                         "FSM|Sorry your repair order could not be processed, and the repair thread"
-                            + " terminated. Staff was notified.",
+                                + " terminated. Staff was notified.",
                         username,
                         false);
                 LOGGER.error(
                         "NOTE: Repair Thread terminated! Use the restartrepairthread command to"
-                            + " restart. If all else fails, reboot.");
+                                + " restart. If all else fails, reboot.");
                 return;
             }
             if (techType == UnitUtils.TECH_PILOT) unit.setPilotIsRepairing(true);
             // charge them for the repair now.
             if (techType == UnitUtils.TECH_REWARD_POINTS) {
-                player.addReward(-cost);
+                player.addRewardPoints(-cost);
             } else {
                 player.addMoney(-cost);
                 unit.addRepairCost(cost);

--- a/MekWarsServer/src/mekwars/server/campaign/commands/RepairUnitCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/RepairUnitCommand.java
@@ -138,7 +138,7 @@ public class RepairUnitCommand implements Command {
                         "FSM|You do not have enough "
                                 + CampaignMain.cm.getConfig("RPLongName")
                                 + " to repair this location.",
-                        Username,
+                        username,
                         false);
                 return;
             }
@@ -153,9 +153,9 @@ public class RepairUnitCommand implements Command {
             }
 
             int numberOfTechs = 1;
-
-            if (techType < UnitUtils.TECH_PILOT) {
-                numberOfTechs = player.getAvailableTechs().get(techType);
+            
+            if (techType < UnitUtils.TECH_TYPES) {
+                numberOfTechs = player.getAvailableTech(techType);
             }
 
             if (techType == UnitUtils.TECH_PILOT

--- a/MekWarsServer/src/mekwars/server/campaign/commands/RepodCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/RepodCommand.java
@@ -470,11 +470,11 @@ public class RepodCommand implements Command {
 
             }// - end Repod costing
         } else {
-            if (p.getReward() < rpCost) {
+            if (p.getRewardPoints() < rpCost) {
                 CampaignMain.cm.toUser("AM:You do not have enough " + CampaignMain.cm.getConfig("RPLongName") + " to repod this unit!", Username, true);
                 return;
             }
-            p.addReward(-rpCost);
+            p.addRewardPoints(-rpCost);
         }
 
         cm.setPilot((SPilot) m.getPilot());

--- a/MekWarsServer/src/mekwars/server/campaign/commands/RetirePilotCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/RetirePilotCommand.java
@@ -79,9 +79,7 @@ public class  RetirePilotCommand  implements Command {
 			if (p.getDutyStatus() != SPlayer.STATUS_RESERVE) {
 				
 				//check the unit's armies.
-				Enumeration<SArmy> f = p.getArmies().elements();
-				while (f.hasMoreElements()) {
-					SArmy currArmy = f.nextElement();
+                for (SArmy currArmy : p.getArmies()) {
 					if (currArmy.getUnit(m.getId()) != null) {
 						CampaignMain.cm.toUser("AM:You may not dismiss/retire a pilot while his unit is part of an active army.",Username,true);
 						return;
@@ -203,9 +201,7 @@ public class  RetirePilotCommand  implements Command {
 			//continue normally. update unit and its armies, etc.
 			CampaignMain.cm.toUser("PL|UU|"+m.getId()+"|"+m.toString(true),Username,false);
 			
-			Enumeration<SArmy> f = p.getArmies().elements();
-			while (f.hasMoreElements()) {
-				SArmy currArmy = f.nextElement();
+            for (SArmy currArmy : p.getArmies()) {
 				if (currArmy.getUnit(m.getId()) != null) {
 					currArmy.setBV(0);//not null so recalc BV of the army
 					CampaignMain.cm.toUser("PL|SAD|"+currArmy.toString(true,"%"),Username,false);

--- a/MekWarsServer/src/mekwars/server/campaign/commands/SalvageUnitCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/SalvageUnitCommand.java
@@ -119,7 +119,7 @@ public class SalvageUnitCommand implements Command {
             int numberOfTechs = 1;
 
             if (techType < UnitUtils.TECH_PILOT) {
-                numberOfTechs = player.getAvailableTechs().elementAt(techType);
+                numberOfTechs = player.getAvailableTechs().get(techType);
             }
 
             if ((techType == UnitUtils.TECH_PILOT) && (unit.getPilot() != null) && (unit.getLastCombatPilot() != unit.getPilot().getPilotId())) {

--- a/MekWarsServer/src/mekwars/server/campaign/commands/SalvageUnitCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/SalvageUnitCommand.java
@@ -119,7 +119,7 @@ public class SalvageUnitCommand implements Command {
             int numberOfTechs = 1;
 
             if (techType < UnitUtils.TECH_PILOT) {
-                numberOfTechs = player.getAvailableTechs().get(techType);
+                numberOfTechs = player.getAvailableTech(techType);
             }
 
             if ((techType == UnitUtils.TECH_PILOT) && (unit.getPilot() != null) && (unit.getLastCombatPilot() != unit.getPilot().getPilotId())) {

--- a/MekWarsServer/src/mekwars/server/campaign/commands/SetMyLogoCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/SetMyLogoCommand.java
@@ -44,7 +44,7 @@ public class SetMyLogoCommand implements Command {
         SPlayer player = CampaignMain.cm.getPlayer(Username);
         
         if ( !command.hasMoreTokens() ){
-            player.setMyLogo(player.getMyHouse().getLogo());
+            player.setLogo(player.getMyHouse().getLogo());
         }else{
     		String newLogo = command.nextToken();
     		if (MWPasswd.getRecord(Username) == null) {
@@ -53,12 +53,12 @@ public class SetMyLogoCommand implements Command {
     		}
             // this way for some reason doesn't work anymore so I'm moving everything to SPlayer. -- Torren
             if ( newLogo.trim().length() < 1 )
-                player.setMyLogo(player.getMyHouse().getLogo());
+                player.setLogo(player.getMyHouse().getLogo());
             else
-                player.setMyLogo(newLogo);
+                player.setLogo(newLogo);
         }
-        CampaignMain.cm.toUser("PL|SUL|"+ player.getMyLogo(),Username,false);
-		CampaignMain.cm.toUser("AM:You've set your Logo to " + player.getMyLogo(),Username,true);
-		CampaignMain.cm.toUser("AM:It'll look like this: <img height=\"150\" width=\"150\" src =\"" + player.getMyLogo() +"\">",Username,true);
+        CampaignMain.cm.toUser("PL|SUL|"+ player.getLogo(),Username,false);
+		CampaignMain.cm.toUser("AM:You've set your Logo to " + player.getLogo(),Username,true);
+		CampaignMain.cm.toUser("AM:It'll look like this: <img height=\"150\" width=\"150\" src =\"" + player.getLogo() +"\">",Username,true);
 	}
 }

--- a/MekWarsServer/src/mekwars/server/campaign/commands/SimpleRepairCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/SimpleRepairCommand.java
@@ -111,7 +111,7 @@ public class SimpleRepairCommand implements Command {
                 int numberOfTechs = 1;
                 int techType = techs.elementAt(type);
                 if ( techType < UnitUtils.TECH_PILOT ){
-                    numberOfTechs = player.getAvailableTechs().get(techType);
+                    numberOfTechs = player.getAvailableTech(techType);
                 }
                 
                 if ( techType == UnitUtils.TECH_PILOT && unit.getPilot() != null

--- a/MekWarsServer/src/mekwars/server/campaign/commands/SimpleRepairCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/SimpleRepairCommand.java
@@ -111,7 +111,7 @@ public class SimpleRepairCommand implements Command {
                 int numberOfTechs = 1;
                 int techType = techs.elementAt(type);
                 if ( techType < UnitUtils.TECH_PILOT ){
-                    numberOfTechs = player.getAvailableTechs().elementAt(techType);
+                    numberOfTechs = player.getAvailableTechs().get(techType);
                 }
                 
                 if ( techType == UnitUtils.TECH_PILOT && unit.getPilot() != null

--- a/MekWarsServer/src/mekwars/server/campaign/commands/TransferRewardPointsCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/TransferRewardPointsCommand.java
@@ -96,8 +96,8 @@ public class TransferRewardPointsCommand implements Command {
 	}
 		
 		//do the transfer
-		player.addReward(-amount);
-		targetplayer.addReward(amount);
+		player.addRewardPoints(-amount);
+		targetplayer.addRewardPoints(amount);
 		CampaignMain.cm.toUser("AM:You've transferred " + amount + " " + CampaignMain.cm.getConfig("RPLongName") + " to " + targetplayer.getName(), Username, true);
 		CampaignMain.cm.toUser("AM:"+player.getName() + " sends you " + amount + " " + CampaignMain.cm.getConfig("RPLongName") + ".", targetPlayer, true);
 

--- a/MekWarsServer/src/mekwars/server/campaign/commands/UseInfluenceCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/UseInfluenceCommand.java
@@ -100,24 +100,24 @@ public class UseInfluenceCommand implements Command {
 				return;
 			}
 
-			if ( rewardPoints > player.getReward() )
+			if ( rewardPoints > player.getRewardPoints() )
 			{
-				if ( player.getReward() == 1)
+				if ( player.getRewardPoints() == 1)
 					CampaignMain.cm.toUser("AM:You only have 1 " + CampaignMain.cm.getConfig("RPShortName") + ". Try again later.",Username,true);
 				else
-					CampaignMain.cm.toUser("AM:You only have " + player.getReward() + " " + CampaignMain.cm.getConfig("RPShortName") + " . Try again later.",Username,true);
+					CampaignMain.cm.toUser("AM:You only have " + player.getRewardPoints() + " " + CampaignMain.cm.getConfig("RPShortName") + " . Try again later.",Username,true);
 				return;
 			}
             if ( CampaignMain.cm.isUsingAdvanceRepair() ){
                 int typeOfTechToBuy = rewardPoints;
                 int techCost = Integer.parseInt(house.getConfig("RewardPointsFor"+UnitUtils.techDescription(typeOfTechToBuy)));
 
-                if ( player.getReward() < techCost ){
+                if ( player.getRewardPoints() < techCost ){
                     CampaignMain.cm.toUser("AM:You do not have enough " + CampaignMain.cm.getConfig("RPLongName") + " to buy this tech. You need "+techCost,Username,true);
                     return;
                 }
 
-                player.addReward(-techCost);
+                player.addRewardPoints(-techCost);
                 player.addTotalTechs(typeOfTechToBuy,1);
                 player.addAvailableTechs(typeOfTechToBuy,1);
                 if (techCost > 1)
@@ -133,7 +133,7 @@ public class UseInfluenceCommand implements Command {
     			if (rewardPoints > 1)
     				rewards = "s";
     			CampaignMain.cm.toUser("AM:You hired " + numOfTechBought + " tech" + techs + " for " + rewardPoints + " " + CampaignMain.cm.getConfig("RPLongName") + rewards +".",Username,true);
-    			player.addReward(-rewardPoints);
+    			player.addRewardPoints(-rewardPoints);
     			player.addTechnicians(numOfTechBought);
             }
 			break;
@@ -151,12 +151,12 @@ public class UseInfluenceCommand implements Command {
 				return;
 			}
 
-			if (rewardPoints > player.getReward()) {
+			if (rewardPoints > player.getRewardPoints()) {
 
-				if (player.getReward() == 0)
+				if (player.getRewardPoints() == 0)
 					CampaignMain.cm.toUser("AM:You don't have any " + CampaignMain.cm.getConfig("RPLongName") + ". Purchase fails.",Username,true);
 				else {
-					String toSend = "AM:You only have " + player.getReward() + CampaignMain.cm.getConfig("RPLongName") + StringUtils.addAnS(player.getReward()) + ". Try again.";
+					String toSend = "AM:You only have " + player.getRewardPoints() + CampaignMain.cm.getConfig("RPLongName") + StringUtils.addAnS(player.getRewardPoints()) + ". Try again.";
 					CampaignMain.cm.toUser(toSend,Username,true);
 				}
 
@@ -167,7 +167,7 @@ public class UseInfluenceCommand implements Command {
 			amountOfInfluenceBought *= rewardPoints;
 			CampaignMain.cm.toUser("AM:You've bought " + CampaignMain.cm.moneyOrFluMessage(false,true,amountOfInfluenceBought)+" for " + rewardPoints + " "+ CampaignMain.cm.getConfig("RPLongName") + StringUtils.addAnS(rewardPoints) + ".",Username,true);
 
-			player.addReward(-rewardPoints);
+			player.addRewardPoints(-rewardPoints);
 			player.addInfluence(amountOfInfluenceBought);
 			break;
 
@@ -176,7 +176,7 @@ public class UseInfluenceCommand implements Command {
 				CampaignMain.cm.toUser("AM:Sorry but you are not allowed to buy units with " + CampaignMain.cm.getConfig("RPLongName") + ".",Username,true);
 				return;
 			}
-			int rewardPointsAvailable = player.getReward();
+			int rewardPointsAvailable = player.getRewardPoints();
 			int unitTotalRewardPointCost = 0;
 			String typestring = command.nextToken();
 			String weightstring = command.nextToken();
@@ -266,7 +266,7 @@ public class UseInfluenceCommand implements Command {
 					player.addUnit(newUnit, true);
 					CampaignMain.cm.toUser("AM:You've bought a " + newUnit.getModelName() + " for " +unitTotalRewardPointCost + " " + CampaignMain.cm.getConfig("RPLongName") + ".",Username,true);
 				}
-				player.addReward(-unitTotalRewardPointCost);
+				player.addRewardPoints(-unitTotalRewardPointCost);
 			} catch (Exception ex){
 				CampaignMain.cm.toUser("AM:An error has occured while trying to create your requested unit. Please contact an admin. Faction: "+factionstring +" Type: "+unitType+" Class: "+unitWeight,Username,true);
 				LOGGER.error("Error creating unit in "+this.getClass().getName());
@@ -276,7 +276,7 @@ public class UseInfluenceCommand implements Command {
         case 3://repairs
             rewardPoints = Integer.parseInt(house.getConfig("RewardPointsForRepair"));
 
-            if ( rewardPoints > player.getReward() ){
+            if ( rewardPoints > player.getRewardPoints() ){
                 CampaignMain.cm.toUser("AM:You need more " + CampaignMain.cm.getConfig("RPLongName") + " to repair this unit (requires " + rewardPoints + " RP)", Username, true);
                 return;
             }
@@ -340,7 +340,7 @@ public class UseInfluenceCommand implements Command {
 
             CampaignMain.cm.toUser("AM:Unit #" + unitID + " "+unit.getModelName()+" is now fully repaired.", Username, true);
             CampaignMain.cm.toUser("PL|UU|"+unit.getId()+"|"+unit.toString(true),Username,false);
-            player.addReward(-rewardPoints);
+            player.addRewardPoints(-rewardPoints);
             player.checkAndUpdateArmies(unit);
             player.setSave();
             break;

--- a/MekWarsServer/src/mekwars/server/campaign/commands/UseRewardPointsCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/UseRewardPointsCommand.java
@@ -102,24 +102,24 @@ public class UseRewardPointsCommand implements Command {
 				return;
 			}
 
-			if ( rewardPoints > player.getReward() )
+			if ( rewardPoints > player.getRewardPoints() )
 			{
-				if ( player.getReward() == 1)
+				if ( player.getRewardPoints() == 1)
 					CampaignMain.cm.toUser("AM:You only have 1 " + CampaignMain.cm.getConfig("RPShortName") + ". Try again later.",Username,true);
 				else
-					CampaignMain.cm.toUser("AM:You only have " + player.getReward() + " " + CampaignMain.cm.getConfig("RPShortName") + " . Try again later.",Username,true);
+					CampaignMain.cm.toUser("AM:You only have " + player.getRewardPoints() + " " + CampaignMain.cm.getConfig("RPShortName") + " . Try again later.",Username,true);
 				return;
 			}
             if ( CampaignMain.cm.isUsingAdvanceRepair() ){
                 int typeOfTechToBuy = rewardPoints;
                 int techCost = Integer.parseInt(house.getConfig("RewardPointsFor"+UnitUtils.techDescription(typeOfTechToBuy)));
 
-                if ( player.getReward() < techCost ){
+                if ( player.getRewardPoints() < techCost ){
                     CampaignMain.cm.toUser("AM:You do not have enough " + CampaignMain.cm.getConfig("RPLongName") + " to buy this tech. You need "+techCost,Username,true);
                     return;
                 }
 
-                player.addReward(-techCost);
+                player.addRewardPoints(-techCost);
                 player.addTotalTechs(typeOfTechToBuy,1);
                 player.addAvailableTechs(typeOfTechToBuy,1);
                 if (techCost > 1)
@@ -135,7 +135,7 @@ public class UseRewardPointsCommand implements Command {
     			if (rewardPoints > 1)
     				rewards = "s";
     			CampaignMain.cm.toUser("AM:You hired " + numOfTechBought + " tech" + techs + " for " + rewardPoints + " " + CampaignMain.cm.getConfig("RPLongName") + rewards +".",Username,true);
-    			player.addReward(-rewardPoints);
+    			player.addRewardPoints(-rewardPoints);
     			player.addTechnicians(numOfTechBought);
             }
 			break;
@@ -153,12 +153,12 @@ public class UseRewardPointsCommand implements Command {
 				return;
 			}
 
-			if (rewardPoints > player.getReward()) {
+			if (rewardPoints > player.getRewardPoints()) {
 
-				if (player.getReward() == 0)
+				if (player.getRewardPoints() == 0)
 					CampaignMain.cm.toUser("AM:You don't have any " + CampaignMain.cm.getConfig("RPLongName") + ". Purchase fails.",Username,true);
 				else {
-					String toSend = "AM:You only have " + player.getReward() + CampaignMain.cm.getConfig("RPLongName") + StringUtils.addAnS(player.getReward()) + ". Try again.";
+					String toSend = "AM:You only have " + player.getRewardPoints() + CampaignMain.cm.getConfig("RPLongName") + StringUtils.addAnS(player.getRewardPoints()) + ". Try again.";
 					CampaignMain.cm.toUser(toSend,Username,true);
 				}
 
@@ -169,7 +169,7 @@ public class UseRewardPointsCommand implements Command {
 			amountOfInfluenceBought *= rewardPoints;
 			CampaignMain.cm.toUser("AM:You've bought " + CampaignMain.cm.moneyOrFluMessage(false,true,amountOfInfluenceBought)+" for " + rewardPoints + " "+ CampaignMain.cm.getConfig("RPLongName") + StringUtils.addAnS(rewardPoints) + ".",Username,true);
 
-			player.addReward(-rewardPoints);
+			player.addRewardPoints(-rewardPoints);
 			player.addInfluence(amountOfInfluenceBought);
 			break;
 
@@ -178,7 +178,7 @@ public class UseRewardPointsCommand implements Command {
 				CampaignMain.cm.toUser("AM:Sorry but you are not allowed to buy units with " + CampaignMain.cm.getConfig("RPLongName") + ".",Username,true);
 				return;
 			}
-			int rewardPointsAvailable = player.getReward();
+			int rewardPointsAvailable = player.getRewardPoints();
 			int unitTotalRewardPointCost = 0;
 			String typestring = command.nextToken();
 			String weightstring = command.nextToken();
@@ -268,7 +268,7 @@ public class UseRewardPointsCommand implements Command {
 					player.addUnit(newUnit, true);
 					CampaignMain.cm.toUser("AM:You've bought a " + newUnit.getModelName() + " for " +unitTotalRewardPointCost + " " + CampaignMain.cm.getConfig("RPLongName") + ".",Username,true);
 				}
-				player.addReward(-unitTotalRewardPointCost);
+				player.addRewardPoints(-unitTotalRewardPointCost);
 			} catch (Exception ex){
 				CampaignMain.cm.toUser("AM:An error has occured while trying to create your requested unit. Please contact an admin. Faction: "+factionstring +" Type: "+unitType+" Class: "+unitWeight,Username,true);
 				LOGGER.error("Exception: ", ex);
@@ -279,7 +279,7 @@ public class UseRewardPointsCommand implements Command {
         case 3://repairs
             rewardPoints = Integer.parseInt(house.getConfig("RewardPointsForRepair"));
 
-            if ( rewardPoints > player.getReward() ){
+            if ( rewardPoints > player.getRewardPoints() ){
                 CampaignMain.cm.toUser("AM:You need more " + CampaignMain.cm.getConfig("RPLongName") + " to repair this unit (requires " + rewardPoints + " RP)", Username, true);
                 return;
             }
@@ -343,7 +343,7 @@ public class UseRewardPointsCommand implements Command {
 
             CampaignMain.cm.toUser("AM:Unit #" + unitID + " "+unit.getModelName()+" is now fully repaired.", Username, true);
             CampaignMain.cm.toUser("PL|UU|"+unit.getId()+"|"+unit.toString(true),Username,false);
-            player.addReward(-rewardPoints);
+            player.addRewardPoints(-rewardPoints);
             player.checkAndUpdateArmies(unit);
             player.setSave();
             break;
@@ -362,12 +362,12 @@ public class UseRewardPointsCommand implements Command {
 				return;
 			}
 
-			if (rewardPoints > player.getReward()) {
+			if (rewardPoints > player.getRewardPoints()) {
 
-				if (player.getReward() == 0)
+				if (player.getRewardPoints() == 0)
 					CampaignMain.cm.toUser("AM:You don't have any " + CampaignMain.cm.getConfig("RPLongName") + ". Purchase fails.",Username,true);
 				else {
-					String toSend = "AM:You only have " + player.getReward() + CampaignMain.cm.getConfig("RPLongName") + StringUtils.addAnS(player.getReward()) + ". Try again.";
+					String toSend = "AM:You only have " + player.getRewardPoints() + CampaignMain.cm.getConfig("RPLongName") + StringUtils.addAnS(player.getRewardPoints()) + ". Try again.";
 					CampaignMain.cm.toUser(toSend,Username,true);
 				}
 
@@ -378,7 +378,7 @@ public class UseRewardPointsCommand implements Command {
 			amountOfCBillsBought *= rewardPoints;
 			CampaignMain.cm.toUser("AM:You've bought " + CampaignMain.cm.moneyOrFluMessage(true,false,amountOfCBillsBought)+" for " + rewardPoints + " "+ CampaignMain.cm.getConfig("RPLongName") + ".",Username,true);
 
-			player.addReward(-rewardPoints);
+			player.addRewardPoints(-rewardPoints);
 			player.addMoney(amountOfCBillsBought);
 			break;
 		}

--- a/MekWarsServer/src/mekwars/server/campaign/commands/mod/CheckCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/mod/CheckCommand.java
@@ -69,7 +69,7 @@ public class CheckCommand implements Command {
 		toMod += "He has " + CampaignMain.cm.moneyOrFluMessage(true,true, p.getMoney())+", ";
 		toMod += p.getExperience() + " EXP, ";
 		toMod += CampaignMain.cm.moneyOrFluMessage(false,true, p.getInfluence()) + " and ";
-		toMod += p.getReward() + " " + CampaignMain.cm.getConfig("RPShortName") + "s.<br>";
+		toMod += p.getRewardPoints() + " " + CampaignMain.cm.getConfig("RPShortName") + "s.<br>";
 		toMod += " - Client version is " + p.getPlayerClientVersion() + ".<br>";
 		toMod += " - IP addess is " + MWServ.getInstance().getIP(p.getName()) + ".<br>";
 		toMod += " - Userlevel is " + MWServ.getInstance().getUserLevel(p.getName()) + ".";

--- a/MekWarsServer/src/mekwars/server/campaign/commands/mod/GrantRewardCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/mod/GrantRewardCommand.java
@@ -42,7 +42,7 @@ public class GrantRewardCommand implements Command {
 		SPlayer p = CampaignMain.cm.getPlayer(command.nextToken());
 		int amount = Integer.parseInt(command.nextToken());
 		if (p != null) {
-			p.setReward(p.getReward() + amount);
+			p.setRewardPoints(p.getRewardPoints() + amount);
 			
 			String toRecipient = "AM:"+Username + " granted you " + amount + " " + CampaignMain.cm.getConfig("RPLongName");
 			if (amount > 0)

--- a/MekWarsServer/src/mekwars/server/campaign/commands/mod/GrantTechsCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/mod/GrantTechsCommand.java
@@ -44,8 +44,8 @@ public class GrantTechsCommand implements Command {
 		int techType = Integer.parseInt(command.nextToken());
 		int amount = Integer.parseInt(command.nextToken());
 		
-		if ( amount < 0 && p.getTotalTechs().get(techType) < Math.abs(amount) ) {
-		    amount = -p.getTotalTechs().get(techType);
+		if ( amount < 0 && p.getTotalTech(techType) < Math.abs(amount) ) {
+		    amount = -p.getTotalTech(techType);
 		}
 		
 		p.addTotalTechs(techType, amount);

--- a/MekWarsServer/src/mekwars/server/campaign/commands/mod/GrantTechsCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/mod/GrantTechsCommand.java
@@ -44,8 +44,8 @@ public class GrantTechsCommand implements Command {
 		int techType = Integer.parseInt(command.nextToken());
 		int amount = Integer.parseInt(command.nextToken());
 		
-		if ( amount < 0 && p.getTotalTechs().elementAt(techType) < Math.abs(amount) ) {
-		    amount = -p.getTotalTechs().elementAt(techType);
+		if ( amount < 0 && p.getTotalTechs().get(techType) < Math.abs(amount) ) {
+		    amount = -p.getTotalTechs().get(techType);
 		}
 		
 		p.addTotalTechs(techType, amount);

--- a/MekWarsServer/src/mekwars/server/campaign/operations/LongValidator.java
+++ b/MekWarsServer/src/mekwars/server/campaign/operations/LongValidator.java
@@ -126,7 +126,7 @@ public class LongValidator {
 			failList.add(LFAILS_PLAYERMONEY);
 		if (reqPlayerFlu > p.getInfluence())
 			failList.add(LFAILS_PLAYERFLU);
-		if (reqPlayerRP > p.getReward())
+		if (reqPlayerRP > p.getRewardPoints())
 			failList.add(LFAILS_PLAYERREWARD);
 		if (reqPlayerXP > p.getExperience())
 			failList.add(LFAILS_PLAYEREXP);

--- a/MekWarsServer/src/mekwars/server/campaign/operations/OperationManager.java
+++ b/MekWarsServer/src/mekwars/server/campaign/operations/OperationManager.java
@@ -364,7 +364,7 @@ public class OperationManager extends AbstractOperationManager implements I_Oper
             toSend += ", " + CampaignMain.cm.moneyOrFluMessage(false, true, -flu, true);
         }
         if (rp > 0) {
-            ap.addReward(-rp);
+            ap.addRewardPoints(-rp);
             toSend += ", -" + rp + " " + CampaignMain.cm.getConfig("RPShortName");
         }
         toSend += ").";
@@ -471,7 +471,7 @@ public class OperationManager extends AbstractOperationManager implements I_Oper
                 didReturn = true;
             }
             if (attrp > 0) {
-                currP.addReward(attrp);
+                currP.addRewardPoints(attrp);
                 if (!didReturn) 
                     toPlayer += " (+" + attrp + " " + CampaignMain.cm.getConfig("RPShortName");
                 else 
@@ -506,7 +506,7 @@ public class OperationManager extends AbstractOperationManager implements I_Oper
                 }
             }
             if (defrp > 0) {
-                currP.addReward(defrp);
+                currP.addRewardPoints(defrp);
                 if (!didReturn) {
                     toPlayer += "(+" + defrp + " " + CampaignMain.cm.getConfig("RPShortName");
                     didReturn = true;

--- a/MekWarsServer/src/mekwars/server/campaign/operations/OpsChickenThread.java
+++ b/MekWarsServer/src/mekwars/server/campaign/operations/OpsChickenThread.java
@@ -132,7 +132,7 @@ public class OpsChickenThread extends Thread {
 
         // add % hits to the totals
         if (rpPercent > 0)
-            totalRPLoss = (int) (pdefender.getReward() * rpPercent);
+            totalRPLoss = (int) (pdefender.getRewardPoints() * rpPercent);
         if (expPercent > 0)
             totalEXPLoss = (int) (pdefender.getExperience() * expPercent);
         if (fluPrecent > 0)
@@ -152,7 +152,7 @@ public class OpsChickenThread extends Thread {
 
         // check totals against the player's amounts and
         // correct to max if the total is too high.
-        totalRPLoss = Math.min(totalRPLoss, pdefender.getReward());
+        totalRPLoss = Math.min(totalRPLoss, pdefender.getRewardPoints());
         totalEXPLoss = Math.min(totalEXPLoss, pdefender.getExperience());
         totalFluLoss = Math.min(totalFluLoss, pdefender.getInfluence());
         totalMoneyLoss = Math.min(totalMoneyLoss, pdefender.getMoney());
@@ -169,7 +169,7 @@ public class OpsChickenThread extends Thread {
                 toPlayer += " (-" + totalRPLoss + " " + CampaignMain.cm.getConfig("RPShortName");
             else
                 toPlayer += ", -" + totalRPLoss + " " + CampaignMain.cm.getConfig("RPShortName");
-            pdefender.addReward(-totalRPLoss);
+            pdefender.addRewardPoints(-totalRPLoss);
             hasLoss = true;
         }
         if (totalEXPLoss > 0) {

--- a/MekWarsServer/src/mekwars/server/campaign/operations/ShortOperation.java
+++ b/MekWarsServer/src/mekwars/server/campaign/operations/ShortOperation.java
@@ -1599,8 +1599,8 @@ public class ShortOperation implements Comparable<Object> {
         SPlayer firstDefPlayer = CampaignMain.cm.getPlayer(firstDefendName);
 
         // Players logo stores House logo as default if they don't have one.
-        String attackLogo = "<img height=\"150\" width=\"150\" src =\"" + firstAttPlayer.getMyLogo() + "\">";
-        String defendLogo = "<img height=\"150\" width=\"150\" src =\"" + firstDefPlayer.getMyLogo() + "\">";
+        String attackLogo = "<img height=\"150\" width=\"150\" src =\"" + firstAttPlayer.getLogo() + "\">";
+        String defendLogo = "<img height=\"150\" width=\"150\" src =\"" + firstDefPlayer.getLogo() + "\">";
 
         // save the logo string ...
         String logos = attackLogo + " vs " + defendLogo + "<br>";

--- a/MekWarsServer/src/mekwars/server/campaign/operations/ShortResolver.java
+++ b/MekWarsServer/src/mekwars/server/campaign/operations/ShortResolver.java
@@ -1379,7 +1379,7 @@ public class ShortResolver {
                 }
 
                 tempBuilder.append(earnedRP + " " + CampaignMain.cm.getConfig("RPShortName"));
-                currP.addReward(earnedRP);
+                currP.addRewardPoints(earnedRP);
                 hasOtherGain = true;
             }
 

--- a/MekWarsServer/src/mekwars/server/campaign/operations/ShortValidator.java
+++ b/MekWarsServer/src/mekwars/server/campaign/operations/ShortValidator.java
@@ -932,7 +932,7 @@ public class ShortValidator {
         if (ap.getInfluence() < o.getIntValue("AttackerCostInfluence"))
             failureReasons.add(SFAIL_ATTACK_INFLUENCE);
 
-        if (ap.getReward() < o.getIntValue("AttackerCostReward"))
+        if (ap.getRewardPoints() < o.getIntValue("AttackerCostReward"))
             failureReasons.add(SFAIL_ATTACK_REWARD);
     }
 
@@ -1432,7 +1432,7 @@ public class ShortValidator {
         if (dp.getInfluence() < o.getIntValue("DefenderCostInfluence"))
             failureReasons.add(SFAIL_DEFEND_INFLUENCE);
 
-        if (dp.getReward() < o.getIntValue("DefenderCostReward"))
+        if (dp.getRewardPoints() < o.getIntValue("DefenderCostReward"))
             failureReasons.add(SFAIL_DEFEND_REWARD);
     }
 

--- a/MekWarsServer/src/mekwars/server/campaign/util/scheduler/UserActivityInfluenceJob.java
+++ b/MekWarsServer/src/mekwars/server/campaign/util/scheduler/UserActivityInfluenceJob.java
@@ -27,8 +27,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.List;
 import java.util.Random;
-import java.util.Vector;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -283,9 +283,9 @@ public class UserActivityInfluenceJob implements Job, MWRepeatingJob, JobIdentif
 			}
 		}
 
-        Vector<SUnit> units = p.getUnits();
+        List<SUnit> units = p.getUnits();
         int unitId = rand.nextInt(units.size());// random
-        SUnit unitForMessages = units.elementAt(unitId);
+        SUnit unitForMessages = units.get(unitId);
         String fluMessageWithPilotName = fluMessage.replaceAll("PILOT", unitForMessages.getPilot().getName());
         String fluMessageWithModelName = fluMessageWithPilotName.replaceAll("UNIT", unitForMessages.getModelName());
         String fluMessageWithPlayerName = fluMessageWithModelName.replaceAll("PLAYER", p.getName());

--- a/MekWarsServer/src/mekwars/server/util/RepairTrackingThread.java
+++ b/MekWarsServer/src/mekwars/server/util/RepairTrackingThread.java
@@ -514,7 +514,7 @@ class Repair{
                                     + " has graduated to "
                                     + StringUtils.aOrAn(UnitUtils.techDescription(techType + 1),true)
                                     + " tech.", Username, false);
-                        } else if ( player.getTotalTechs().get(techType) > 0){
+                        } else if ( player.getTotalTech(techType) > 0){
                             // AvailableTech was already removed so just move the tech to the next level
                             player.addAvailableTechs(techType + 1, 1);
                             // Now remove the tech from its old class and move it to its new class
@@ -528,7 +528,7 @@ class Repair{
                         }
                     }
 
-                    if (retireTech && (player.getTotalTechs().get(techType) > 0) ) {
+                    if (retireTech && (player.getTotalTech(techType) > 0) ) {
                         CampaignMain.cm.toUser(
                                 "FSM|<font color=#ff80ff>One of your "
                                         + UnitUtils.techDescription(techType)

--- a/MekWarsServer/src/mekwars/server/util/RepairTrackingThread.java
+++ b/MekWarsServer/src/mekwars/server/util/RepairTrackingThread.java
@@ -514,7 +514,7 @@ class Repair{
                                     + " has graduated to "
                                     + StringUtils.aOrAn(UnitUtils.techDescription(techType + 1),true)
                                     + " tech.", Username, false);
-                        } else if ( player.getTotalTechs().elementAt(techType) > 0){
+                        } else if ( player.getTotalTechs().get(techType) > 0){
                             // AvailableTech was already removed so just move the tech to the next level
                             player.addAvailableTechs(techType + 1, 1);
                             // Now remove the tech from its old class and move it to its new class
@@ -528,7 +528,7 @@ class Repair{
                         }
                     }
 
-                    if (retireTech && (player.getTotalTechs().elementAt(techType) > 0) ) {
+                    if (retireTech && (player.getTotalTechs().get(techType) > 0) ) {
                         CampaignMain.cm.toUser(
                                 "FSM|<font color=#ff80ff>One of your "
                                         + UnitUtils.techDescription(techType)

--- a/MekWarsServer/src/mekwars/server/util/SPlayerToJSON.java
+++ b/MekWarsServer/src/mekwars/server/util/SPlayerToJSON.java
@@ -23,7 +23,7 @@ public class SPlayerToJSON {
     public static void writeToFile(SPlayer player)
     {
     	startJson();
-    	stringJson("myLogo",player.getMyLogo());
+    	stringJson("myLogo",player.getLogo());
     	stringJson("name",player.getName());
     	stringJson("discordID",player.getDiscordID());
     	stringJson("house",player.getMyHouse().getName());

--- a/MekWarsServer/src/mekwars/server/util/SPlayerToJSON.java
+++ b/MekWarsServer/src/mekwars/server/util/SPlayerToJSON.java
@@ -33,7 +33,7 @@ public class SPlayerToJSON {
     	intJson("experience",player.getExperience());
     	intJson("money",player.getMoney());
     	intJson("influence",player.getInfluence());
-    	intJson("rewardPoints",player.getReward());
+    	intJson("rewardPoints",player.getRewardPoints());
     	endJson();
     	   	
 		File pathCheck = new File("data/discord/players");

--- a/MekWarsServer/unittests/mekwars/server/campaign/SPlayerTest.java
+++ b/MekWarsServer/unittests/mekwars/server/campaign/SPlayerTest.java
@@ -1,0 +1,186 @@
+/*
+ * MekWars - Copyright (C) 2026
+ *
+ * Derived from MegaMekNET (http://www.sourceforge.net/projects/megameknet)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+package mekwars.server.campaign;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import mekwars.common.CampaignData;
+import mekwars.common.campaign.CampaignOptions;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Hashtable;
+
+@ExtendWith(MockitoExtension.class)
+class SPlayerTest {
+    @Mock private SHouse house;
+
+    @Mock private CampaignMain campaignMain;
+
+    @Mock private CampaignData campaignData;
+
+    @Mock private CampaignOptions campaignOptions;
+
+    private SPlayer player;
+
+    @BeforeEach
+    public void setup() {
+        CampaignMain.cm = campaignMain;
+        CampaignData.cd = campaignData;
+        when(CampaignMain.cm.getIntegerConfig("NoPlayListSize")).thenReturn(5);
+        when(campaignData.getCampaignOptions()).thenReturn(campaignOptions);
+        when(campaignOptions.getConfig("NewbieHouseName")).thenReturn("NoHouse");
+        when(CampaignData.cd.getHouseByName("NoHouse")).thenReturn(house);
+
+        player = spy(new SPlayer());
+    }
+
+    @Test
+    public void testAddMoney_PreventsNegativeBalance() {
+        when(house.getIntegerConfig("MaxSOLCBills")).thenReturn(1_000);
+
+        player.addMoney(100);
+        player.addMoney(-150);
+
+        assertEquals(0, player.getMoney());
+    }
+
+    @Nested
+    class GetRemainingMekTokensTest {
+        @Test
+        public void testCalculatesCorrectly() {
+            int freeBuildLimit = 10;
+            when(house.getConfig("FreeBuild_Limit")).thenReturn(Integer.toString(freeBuildLimit));
+            when(house.getIntegerConfig("FreeBuild_Limit")).thenReturn(freeBuildLimit);
+            doNothing().when(CampaignMain.cm).toUser("PL|UMT|3", "", false);
+            doNothing().when(player).setSave();
+
+            player.addMekToken(3);
+
+            assertEquals(7, player.getRemainingMekTokens());
+            assertEquals(10, player.getMekTokenLimit());
+        }
+
+        @Test
+        public void testHasUnusedReturnsTrue() {
+            when(house.getConfig("FreeBuild_Limit")).thenReturn("5");
+
+            player.addMekToken(2);
+
+            assertTrue(player.hasUnusedMekTokens());
+        }
+    }
+
+    @Nested
+    class AddExperienceTest {
+        private Hashtable<String, SmallPlayer> smallPlayers = new Hashtable<>();
+
+        @BeforeEach
+        public void setup() {
+            when(player.getMyHouse()).thenReturn(house);
+            when(player.getMyHouse().getSmallPlayers()).thenReturn(smallPlayers);
+        }
+
+        @Test
+        public void testRewardRolloverTriggersRewardPoints() {
+            when(house.getIntegerConfig("MinimumHouseBays")).thenReturn(20);
+            when(house.getIntegerConfig("XPRollOverCap")).thenReturn(100);
+            when(house.getIntegerConfig("FluXPRollOverCap")).thenReturn(0);
+            when(campaignMain.getConfig("RPShortName")).thenReturn("RP");
+            doNothing().when(campaignMain).toUser(anyString(), anyString(), anyBoolean());
+
+            /*
+             * Start with 90 XP, add 20 -> 110. Should roll over 100, grant 1 RP, reset counter to 10
+             */
+            player.addExperience(90, false);
+            player.addExperience(20, false);
+
+            assertEquals(10, player.getXpTillReward());
+            verify(player).addRewardPoints(1);
+            verify(player).setXpTillReward(10);
+        }
+
+        @Test
+        public void testRewardRollver_DoesNotTriggerRewardPoints() {
+            when(house.getIntegerConfig("MinimumHouseBays")).thenReturn(20);
+            when(house.getIntegerConfig("XPRollOverCap")).thenReturn(100);
+            when(house.getIntegerConfig("FluXPRollOverCap")).thenReturn(0);
+            doNothing().when(campaignMain).toUser(anyString(), anyString(), anyBoolean());
+
+            /*
+             * Start with 90 XP, add 20 -> 110. Should roll over 100, but does not grant an RP because
+             * a moderator gave experience.
+             */
+            player.addExperience(90, true);
+            player.addExperience(20, false);
+
+            assertEquals(20, player.getXpTillReward());
+            verify(player, never()).addRewardPoints(1);
+            verify(player).setXpTillReward(20);
+        }
+
+        @Test
+        public void testFluRolloverTriggersInfluence() {
+            when(house.getIntegerConfig("MinimumHouseBays")).thenReturn(20);
+            when(house.getIntegerConfig("XPRollOverCap")).thenReturn(0);
+            when(house.getIntegerConfig("FluXPRollOverCap")).thenReturn(100);
+            when(campaignMain.getConfig("FluShortName")).thenReturn("FLU");
+            doNothing().when(campaignMain).toUser(anyString(), anyString(), anyBoolean());
+
+            /*
+             * Start with 90 XP, add 20 -> 110. Should roll over 100, grant 1 FLU, reset counter to 10
+             */
+            player.addExperience(90, false);
+            player.addExperience(20, false);
+
+            assertEquals(10, player.getXpTillFlu());
+            verify(player).addInfluence(1);
+            verify(player).setXpTillFlu(10);
+        }
+
+        @Test
+        public void testFluRollover_DoesNotTriggersInfluence() {
+            when(house.getIntegerConfig("MinimumHouseBays")).thenReturn(20);
+            when(house.getIntegerConfig("XPRollOverCap")).thenReturn(0);
+            when(house.getIntegerConfig("FluXPRollOverCap")).thenReturn(100);
+            doNothing().when(campaignMain).toUser(anyString(), anyString(), anyBoolean());
+
+            /*
+             * Start with 90 XP, add 20 -> 110. Should roll over 100, but does not grant a FLU because a moderator gave experience.
+             */
+            player.addExperience(90, true);
+            player.addExperience(20, false);
+
+            assertEquals(20, player.getXpTillFlu());
+            verify(player, never()).addInfluence(1);
+            verify(player).setXpTillFlu(20);
+        }
+
+        @Test
+        public void testPreventsNegative() {
+            player.addExperience(-50, false);
+
+            assertEquals(0, player.getExperience());
+        }
+    }
+}


### PR DESCRIPTION
This PR is the original reason for the previous two PRs. SPlayer and CPlayer have many members that are duplicated and several methods, specifically `doPayTechniciansMath`. `doPayTechniciansMath` could not be moved into `Player` as the server and client had different ways to get the config and the client had no API to get the house config.

This PR starts to modernize `SPlayer`, `CPlayer`, `Player`, by de-duplicating code, adding several tests, and replacing `Vector` with `ArrayList`.

Personally I don't like templating `Player`, but it seems necessary to allow `SPlayer` and `CPlayer` to have an `ArrayList<SUnit>` and `ArrayList<CUnit>`. My hope however is a lot of the differences between the client and server classes can eventually be put into the base classes and make this template unneeded.