### PR TITLE
#124 Add SyncLog table

### DIFF
--- a/MekWarsCommon/src/main/resources/db/migration/V1__init_schema.sql
+++ b/MekWarsCommon/src/main/resources/db/migration/V1__init_schema.sql
@@ -1,0 +1,9 @@
+CREATE TABLE sync_log (
+	id         INTEGER PRIMARY KEY AUTOINCREMENT,
+	entity_id  INTEGER NOT NULL,
+	table_name TEXT NOT NULL,
+	operation  INTEGER NOT NULL,
+	updated_at TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX sync_log_entity_id_table_name_index ON sync_log(entity_id, table_name);

--- a/MekWarsCommon/src/mekwars/common/sync/SyncEntity.java
+++ b/MekWarsCommon/src/mekwars/common/sync/SyncEntity.java
@@ -1,0 +1,60 @@
+/*
+ * MekWars - Copyright (C) 2026
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ */
+
+package mekwars.common.sync;
+
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Id;
+
+@MappedSuperclass
+public abstract class SyncEntity {
+    public enum Action {
+        INSERT(0),
+        UPDATE(1),
+        DELETE(2);
+
+        private static final Action[] VALUES = values();
+        private final int value;
+
+        Action(int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return value;
+        }
+
+        public static Action fromInt(int value) {
+            for (Action action : VALUES) {
+                if (action.getValue() == value) {
+                    return action;
+                }
+            }
+            throw new IllegalArgumentException("No matching Action for value: " + value);
+        }
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+}

--- a/MekWarsCommon/src/mekwars/common/sync/SyncLogIntegrator.java
+++ b/MekWarsCommon/src/mekwars/common/sync/SyncLogIntegrator.java
@@ -1,0 +1,44 @@
+/*
+ * MekWars - Copyright (C) 2026
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ */
+package mekwars.common.sync;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.spi.BootstrapContext;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.event.service.spi.EventListenerRegistry;
+import org.hibernate.event.spi.EventType;
+import org.hibernate.integrator.spi.Integrator;
+import org.hibernate.service.spi.SessionFactoryServiceRegistry;
+
+public class SyncLogIntegrator implements Integrator {
+
+    @Override
+    public void integrate(
+            Metadata metadata,
+            BootstrapContext bootstrapContext,
+            SessionFactoryImplementor sessionFactory) {
+
+        SyncLogListener listener = new SyncLogListener();
+        EventListenerRegistry registry =
+                sessionFactory.getServiceRegistry().getService(EventListenerRegistry.class);
+
+        registry.appendListeners(EventType.POST_INSERT, listener);
+        registry.appendListeners(EventType.POST_UPDATE, listener);
+        registry.appendListeners(EventType.POST_DELETE, listener);
+    }
+
+    @Override
+    public void disintegrate(
+            SessionFactoryImplementor sessionFactory,
+            SessionFactoryServiceRegistry serviceRegistry) {}
+}

--- a/MekWarsCommon/src/mekwars/common/sync/SyncLogListener.java
+++ b/MekWarsCommon/src/mekwars/common/sync/SyncLogListener.java
@@ -1,0 +1,93 @@
+/*
+ * MekWars - Copyright (C) 2026
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ */
+
+package mekwars.common.sync;
+
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.event.spi.PostDeleteEvent;
+import org.hibernate.event.spi.PostDeleteEventListener;
+import org.hibernate.event.spi.PostInsertEvent;
+import org.hibernate.event.spi.PostInsertEventListener;
+import org.hibernate.event.spi.PostUpdateEvent;
+import org.hibernate.event.spi.PostUpdateEventListener;
+import org.hibernate.persister.entity.EntityPersister;
+
+import java.time.ZonedDateTime;
+
+public class SyncLogListener
+        implements PostInsertEventListener, PostUpdateEventListener, PostDeleteEventListener {
+
+    @Override
+    public void onPostInsert(PostInsertEvent event) {
+        if (event.getEntity() instanceof SyncEntity) {
+            SyncEntity entity = (SyncEntity) event.getEntity();
+
+            writeSyncLog(
+                    event.getSession(),
+                    entity.getId(),
+                    event.getEntity().getClass().getSimpleName(),
+                    SyncEntity.Action.INSERT.getValue());
+        }
+    }
+
+    @Override
+    public void onPostUpdate(PostUpdateEvent event) {
+        if (event.getEntity() instanceof SyncEntity) {
+            SyncEntity entity = (SyncEntity) event.getEntity();
+
+            writeSyncLog(
+                    event.getSession(),
+                    entity.getId(),
+                    event.getEntity().getClass().getSimpleName(),
+                    SyncEntity.Action.UPDATE.getValue());
+        }
+    }
+
+    @Override
+    public void onPostDelete(PostDeleteEvent event) {
+        if (event.getEntity() instanceof SyncEntity) {
+            SyncEntity entity = (SyncEntity) event.getEntity();
+
+            writeSyncLog(
+                    event.getSession(),
+                    entity.getId(),
+                    event.getEntity().getClass().getSimpleName(),
+                    SyncEntity.Action.DELETE.getValue());
+        }
+    }
+
+    @Override
+    public boolean requiresPostCommitHandling(EntityPersister persister) {
+        return false;
+    }
+
+    private void writeSyncLog(
+            SharedSessionContractImplementor session, int id, String table, int op) {
+        String statement =
+                "INSERT INTO sync_log (entity_id, table_name, operation, updated_at) "
+                        + "VALUES (?, ?, ?, ?) "
+                        + "ON CONFLICT(entity_id, table_name) DO UPDATE SET "
+                        + "id = excluded.id, "
+                        + "operation = excluded.operation, "
+                        + "updated_at = excluded.updated_at";
+        session.doWork(
+                conn -> {
+                    try (var ps = conn.prepareStatement(statement)) {
+                        ps.setInt(1, id);
+                        ps.setInt(2, op);
+                        ps.setString(3, ZonedDateTime.now().toString());
+                        ps.executeUpdate();
+                    }
+                });
+    }
+}

--- a/MekWarsServer/build.gradle
+++ b/MekWarsServer/build.gradle
@@ -8,6 +8,9 @@ sourceSets {
         java {
             srcDirs = ['src']
         }
+        resources {
+               srcDirs = ['resources']
+        }
     }
 
     test {

--- a/MekWarsServer/resources/META-INF/services/org.hibernate.integrator.spi.Integrator
+++ b/MekWarsServer/resources/META-INF/services/org.hibernate.integrator.spi.Integrator
@@ -1,0 +1,1 @@
+mekwars.common.sync.SyncLogIntegrator


### PR DESCRIPTION
This is the beginnings of replacing the DataFetch's sync capability. As it stands the DataFetchClient only syncs a few classes, (Planet, House). Both of these objects have their own `Time...` class that adds a `last_updated` timestamp to check if its in sync. However there seems to be no method of checking for deletion and both have to be manually checked. Any additional object that wants to be added to the DataFetchClient need to be stored in `CampaignData` and have its serialization code manually written. 

The SyncLog intends to make it easier to determine which objects have been modified as opposed to iterating over every instance. Later work would be able to replace the DataFetch/CampaignData entirely and allow for async updates.