### PR TITLE
Rename Entity -> MWEntity

### DIFF
--- a/MekWarsCommon/src/mekwars/common/AdvancedTerrain.java
+++ b/MekWarsCommon/src/mekwars/common/AdvancedTerrain.java
@@ -19,8 +19,8 @@ package mekwars.common;
 
 import java.io.IOException;
 import java.util.StringTokenizer;
-import mekwars.common.entities.Entity;
-import mekwars.common.persistence.EntityStore;
+import mekwars.common.entities.MWEntity;
+import mekwars.common.persistence.MWEntityStore;
 import mekwars.common.util.BinReader;
 import mekwars.common.util.BinWriter;
 import mekwars.common.util.TokenReader;
@@ -39,9 +39,9 @@ import megamek.common.planetaryconditions.WindDirection;
  * @@author Torren (Jason Tighe) allows So's to set up each individual terrain on a planet.
  */
 
-public class AdvancedTerrain implements Entity {
+public class AdvancedTerrain implements MWEntity {
     private String displayName = "none";
-    private int id = EntityStore.UNSET_ID;
+    private int id = MWEntityStore.UNSET_ID;
     private String name = "none";
     
     //NOTE: These fields are unused and kept to keep the xml file consistent

--- a/MekWarsCommon/src/mekwars/common/CampaignData.java
+++ b/MekWarsCommon/src/mekwars/common/CampaignData.java
@@ -19,7 +19,7 @@ package mekwars.common;
 import mekwars.common.campaign.CampaignOptions;
 import mekwars.common.campaign.HouseOptions;
 import mekwars.common.persistence.BannedAmmoStore;
-import mekwars.common.persistence.NamedEntityStore;
+import mekwars.common.persistence.NamedMWEntityStore;
 import mekwars.common.util.BinReader;
 import mekwars.common.util.BinWriter;
 
@@ -53,10 +53,10 @@ public class CampaignData implements TerrainProvider {
 
     public static CampaignData cd;
 
-    private NamedEntityStore<House> factions = new NamedEntityStore<>();
-    private NamedEntityStore<Planet> planets = new NamedEntityStore<>();
-    private NamedEntityStore<Terrain> terrains = new NamedEntityStore<>();
-    private NamedEntityStore<AdvancedTerrain> advancedTerrains = new NamedEntityStore<>();
+    private NamedMWEntityStore<House> factions = new NamedMWEntityStore<>();
+    private NamedMWEntityStore<Planet> planets = new NamedMWEntityStore<>();
+    private NamedMWEntityStore<Terrain> terrains = new NamedMWEntityStore<>();
+    private NamedMWEntityStore<AdvancedTerrain> advancedTerrains = new NamedMWEntityStore<>();
 
     private Vector<Integer> bannedTargetingSystems = new Vector<>();
     private HashMap<String, Integer> commands = new HashMap<>();

--- a/MekWarsCommon/src/mekwars/common/House.java
+++ b/MekWarsCommon/src/mekwars/common/House.java
@@ -20,8 +20,8 @@
  */
 package mekwars.common;
 
-import mekwars.common.entities.Entity;
-import mekwars.common.persistence.EntityStore;
+import mekwars.common.entities.MWEntity;
+import mekwars.common.persistence.MWEntityStore;
 import mekwars.common.util.BinReader;
 import mekwars.common.util.BinWriter;
 import mekwars.common.util.HTMLConverter;
@@ -39,7 +39,7 @@ import org.apache.logging.log4j.Logger;
  * @author Helge Richter
  * 
  */
-public class House implements Entity {
+public class House implements MWEntity {
     private static final Logger LOGGER = LogManager.getLogger(House.class);
     
     public static final int RED_VALUE = 0;
@@ -286,7 +286,7 @@ public class House implements Entity {
     }
 
     public House() {
-        setId(EntityStore.UNSET_ID);
+        setId(MWEntityStore.UNSET_ID);
         for (int pos = 0; pos < Unit.MAXBUILD; pos++) {
             baseGunner.add(4);
             basePilot.add(5);

--- a/MekWarsCommon/src/mekwars/common/Planet.java
+++ b/MekWarsCommon/src/mekwars/common/Planet.java
@@ -20,8 +20,8 @@
  */
 package mekwars.common;
 
-import mekwars.common.entities.Entity;
-import mekwars.common.persistence.EntityStore;
+import mekwars.common.entities.MWEntity;
+import mekwars.common.persistence.MWEntityStore;
 import mekwars.common.util.BinReader;
 import mekwars.common.util.BinWriter;
 import mekwars.common.util.Position;
@@ -39,12 +39,12 @@ import java.util.TreeMap;
 /**
  * @author Helge Richter
  */
-public class Planet implements Comparable<Object>, MutableSerializable, Entity {
+public class Planet implements Comparable<Object>, MutableSerializable, MWEntity {
     /**
      * Unique id of this planet. Mutable field (although it will not change, it has to be
      * transfered)
      */
-    private int id = EntityStore.UNSET_ID;
+    private int id = MWEntityStore.UNSET_ID;
 
     /** name of the planet. Should be unique among planets too. */
     private String name;

--- a/MekWarsCommon/src/mekwars/common/Terrain.java
+++ b/MekWarsCommon/src/mekwars/common/Terrain.java
@@ -15,8 +15,8 @@
 
 package mekwars.common;
 
-import mekwars.common.entities.Entity;
-import mekwars.common.persistence.EntityStore;
+import mekwars.common.entities.MWEntity;
+import mekwars.common.persistence.MWEntityStore;
 import mekwars.common.util.BinReader;
 import mekwars.common.util.BinWriter;
 
@@ -29,9 +29,9 @@ import java.util.StringTokenizer;
  * A Terrain Base Terrain container for all environments. Each environment can be a different theme
  * to allow for different times of year.
  */
-public final class Terrain implements Entity {
+public final class Terrain implements MWEntity {
     // id
-    private int id = EntityStore.UNSET_ID;
+    private int id = MWEntityStore.UNSET_ID;
     private String name = "None";
     private List<PlanetEnvironment> environments = new ArrayList<PlanetEnvironment>();
 

--- a/MekWarsCommon/src/mekwars/common/entities/BannedAmmo.java
+++ b/MekWarsCommon/src/mekwars/common/entities/BannedAmmo.java
@@ -20,7 +20,7 @@ import java.util.Set;
 import java.util.HashMap;
 import java.util.Map;
 
-public class BannedAmmo implements Entity {
+public class BannedAmmo implements MWEntity {
     private static HashMap<String, AmmoType.Munitions> MUNITIONS_BY_NAME = createMunitionsByName();
     private static HashMap<AmmoType.Munitions, String> MUNITIONS_BY_NUMBER =
             createMunitionsByNumber();

--- a/MekWarsCommon/src/mekwars/common/entities/MWEntity.java
+++ b/MekWarsCommon/src/mekwars/common/entities/MWEntity.java
@@ -16,7 +16,7 @@
 
 package mekwars.common.entities;
 
-public interface Entity {
+public interface MWEntity {
     int getId();
 
     void setId(int id);

--- a/MekWarsCommon/src/mekwars/common/persistence/MWEntityStore.java
+++ b/MekWarsCommon/src/mekwars/common/persistence/MWEntityStore.java
@@ -20,21 +20,21 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import mekwars.common.entities.Entity;
+import mekwars.common.entities.MWEntity;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class EntityStore<T extends Entity> {
-    private static final Logger LOGGER = LogManager.getLogger(EntityStore.class);
+public class MWEntityStore<T extends MWEntity> {
+    private static final Logger LOGGER = LogManager.getLogger(MWEntityStore.class);
 
     public static final int UNSET_ID = -1;
 
     protected SortedMap<Integer, T> entities = Collections.synchronizedSortedMap(new TreeMap());
 
     /**
-     * Adds an Entity to the EntityStore.
+     * Adds an MWEntity to the MWEntityStore.
      *
-     * @param entity The {@link Entity} to add to the {@link EntityStore}.
+     * @param entity The {@link MWEntity} to add to the {@link MWEntityStore}.
      */
     public void put(T entity) {
         LOGGER.info("Adding {}: '{}'", entity.getClass().getSimpleName(), entity.getName());
@@ -48,9 +48,9 @@ public class EntityStore<T extends Entity> {
     /**
      * Gets an entity by their id.
      *
-     * @param id The id of the {@link Entity} to retrieve.
+     * @param id The id of the {@link MWEntity} to retrieve.
      *
-     * @return The {@link Entity} of the given id.
+     * @return The {@link MWEntity} of the given id.
      */
     public T get(int id) {
         return entities.get(id);
@@ -59,16 +59,16 @@ public class EntityStore<T extends Entity> {
     /**
      * Removes an entity by their id.
      *
-     * @param id The id of the {@link Entity} to remove.
+     * @param id The id of the {@link MWEntity} to remove.
      *
-     * @return The {@link Entity} that is associated with the given id.
+     * @return The {@link MWEntity} that is associated with the given id.
      */
     public T remove(int id) {
         return entities.remove(id);
     }
 
     /**
-     * Removes all entities from the EntityStore.
+     * Removes all entities from the MWEntityStore.
      */
     public void clear() {
         entities.clear();
@@ -77,17 +77,17 @@ public class EntityStore<T extends Entity> {
     /**
      * Returns a list of all stores entities.
      *
-     * @return A Collection of all {@link Entity entities}.
+     * @return A Collection of all {@link MWEntity entities}.
      */
     public Collection<T> values() {
         return entities.values();
     }
 
     /**
-     * Returns the number of entities in the EntityStore. If the Entity store contains more than
+     * Returns the number of entities in the MWEntityStore. If the MWEntity store contains more than
      * Integer.MAX_VALUE elements, returns Integer.MAX_VALUE.
      *
-     * @return The number of {@link Entity entities} in this {@link EntityStore}
+     * @return The number of {@link MWEntity entities} in this {@link MWEntityStore}
      */
     public int size() {
         return entities.size();
@@ -96,7 +96,7 @@ public class EntityStore<T extends Entity> {
     /**
      * Returns the next available id free for an entity.
      *
-     * @return The next available id free for an {@link Entity}.
+     * @return The next available id free for an {@link MWEntity}.
      */
     protected int nextId() {
         return entities.keySet().stream().max(Integer::compare).orElse(0) + 1;

--- a/MekWarsCommon/src/mekwars/common/persistence/NamedMWEntityStore.java
+++ b/MekWarsCommon/src/mekwars/common/persistence/NamedMWEntityStore.java
@@ -1,6 +1,6 @@
 /*
  * MekWars - Copyright (C) 2025
- * 
+ *
  * Derived from MegaMekNET (http://www.sourceforge.net/projects/megameknet)
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -16,23 +16,25 @@
 
 package mekwars.common.persistence;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.SortedMap;
-import java.util.TreeMap;
-import mekwars.common.entities.Entity;
+import mekwars.common.entities.MWEntity;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class NamedEntityStore<T extends Entity> extends EntityStore<T> {
-    private static final Logger LOGGER = LogManager.getLogger(NamedEntityStore.class);
+import java.util.Collections;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
-    protected SortedMap<String, Integer> entityNames = Collections.synchronizedSortedMap(new TreeMap());
+public class NamedMWEntityStore<T extends MWEntity> extends MWEntityStore<T> {
+    private static final Logger LOGGER = LogManager.getLogger(NamedMWEntityStore.class);
+
+    protected SortedMap<String, Integer> entityNames =
+            Collections.synchronizedSortedMap(new TreeMap());
 
     /**
-     * Adds an Entity to the EntityStore.
+     * Adds an MWEntity to the MWEntityStore.
      *
-     * @param entity The {@link Entity} to add to the {@link EntityStore}.
+     * @param entity The {@link MWEntity} to add to the {@link MWEntityStore}.
      */
     public void put(T entity) {
         LOGGER.info("Adding {}: '{}'", entity.getClass().getSimpleName(), entity.getName());
@@ -43,7 +45,7 @@ public class NamedEntityStore<T extends Entity> extends EntityStore<T> {
         entities.put(entity.getId(), entity);
         String entityName = entity.getName().toLowerCase();
         if (entityNames.containsKey(entityName)) {
-            LOGGER.error("Entity {} already exists", entityName);
+            LOGGER.error("MWEntity {} already exists", entityName);
             throw new IllegalArgumentException();
         }
         entityNames.put(entityName, entity.getId());
@@ -52,9 +54,8 @@ public class NamedEntityStore<T extends Entity> extends EntityStore<T> {
     /**
      * Gets an entity by their name.
      *
-     * @param name The name of the {@link Entity} to retrieve.
-     *
-     * @return The {@link Entity} of the given name.
+     * @param name The name of the {@link MWEntity} to retrieve.
+     * @return The {@link MWEntity} of the given name.
      */
     public T getByName(String name) {
         if (name == null) {
@@ -73,9 +74,8 @@ public class NamedEntityStore<T extends Entity> extends EntityStore<T> {
     /**
      * Removes an entity by their id.
      *
-     * @param id The id of the {@link Entity} to remove.
-     *
-     * @return The {@link Entity} that is associated with the given id.
+     * @param id The id of the {@link MWEntity} to remove.
+     * @return The {@link MWEntity} that is associated with the given id.
      */
     public T remove(int id) {
         T entity = get(id);
@@ -87,9 +87,7 @@ public class NamedEntityStore<T extends Entity> extends EntityStore<T> {
         return entities.remove(id);
     }
 
-    /**
-     * Removes all entities from the EntityStore.
-     */
+    /** Removes all entities from the MWEntityStore. */
     public void clear() {
         super.clear();
         entityNames.clear();

--- a/MekWarsCommon/unittests/mekwars/common/CampaignDataTest.java
+++ b/MekWarsCommon/unittests/mekwars/common/CampaignDataTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
 import mekwars.common.campaign.CampaignOptions;
-import mekwars.common.persistence.EntityStore;
+import mekwars.common.persistence.MWEntityStore;
 import mekwars.common.util.Position;
 
 import org.junit.jupiter.api.Test;
@@ -42,7 +42,7 @@ class CampaignDataTest {
     public void testAddPlanet() {
         Planet testPlanet = new Planet("TestPlanet1", position, influence);
 
-        assertEquals(EntityStore.UNSET_ID, testPlanet.getId());
+        assertEquals(MWEntityStore.UNSET_ID, testPlanet.getId());
         data.addPlanet(testPlanet);
         assertEquals(1, testPlanet.getId());
     }
@@ -51,7 +51,7 @@ class CampaignDataTest {
     public void testAddHouse() {
         House testHouse = new House();
 
-        assertEquals(EntityStore.UNSET_ID, testHouse.getId());
+        assertEquals(MWEntityStore.UNSET_ID, testHouse.getId());
         data.addHouse(testHouse);
         assertEquals(1, testHouse.getId());
     }

--- a/MekWarsCommon/unittests/mekwars/common/PlanetTest.java
+++ b/MekWarsCommon/unittests/mekwars/common/PlanetTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
-import mekwars.common.persistence.EntityStore;
+import mekwars.common.persistence.MWEntityStore;
 import mekwars.common.util.Position;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -46,7 +46,7 @@ class PlanetTest {
     public void testId() {
         Planet testPlanet = new Planet("TestPlanet1", position, influence);
 
-        assertEquals(EntityStore.UNSET_ID, testPlanet.getId());
+        assertEquals(MWEntityStore.UNSET_ID, testPlanet.getId());
     }
 
     @Nested


### PR DESCRIPTION
Same idea as #188 designed to shrink the Hibernate PR to be more reasonable. This is done to clear the `Entity` keyword for Hibernate to use cleanly. As a reminder these classes are also a stopgap for Hibernate so they should be going away once Hibernate has been successfully added as well.