### PR TITLE
RFC: Refactor Player to use composition for units

### DIFF
--- a/MekWarsClient/src/mekwars/client/campaign/CPlayer.java
+++ b/MekWarsClient/src/mekwars/client/campaign/CPlayer.java
@@ -20,6 +20,8 @@ package mekwars.client.campaign;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -41,13 +43,14 @@ import mekwars.common.util.UnitComponents;
 import mekwars.common.util.UnitUtils;
 import megamek.common.CriticalSlot;
 import megamek.common.OffBoardDirection;
+import mekwars.common.composition.HasUnits;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
  * Class for Player object used by Client
  */
-public class CPlayer extends Player<CUnit> {
+public class CPlayer extends Player {
     private static final Logger LOGGER = LogManager.getLogger(CPlayer.class);
 
     public static final String DELIMITER = "#"; // delimiter for player strings
@@ -60,6 +63,7 @@ public class CPlayer extends Player<CUnit> {
     private int hangarPenalty;
     private int hangarPurchasePenalties[][] = new int[6][4];
 
+    private HasUnits<CUnit> units = new HasUnits<>();
     private List<CArmy> armies;
     private List<CUnit> autoArmy;
 
@@ -91,6 +95,77 @@ public class CPlayer extends Player<CUnit> {
         personalPilotQueue = new CPersonalPilotQueues();
         adminExcludes = new ArrayList<String>();
         playerExcludes = new ArrayList<String>();
+    }
+
+    /**
+     * @see IHasUnits#getUnits
+     */
+    public List<CUnit> getUnits() {
+        return (List<CUnit>) Collections.unmodifiableList(units.getAll());
+    }
+
+    /**
+     * @see IHasUnits#getUnit(int)
+     */
+    public CUnit getUnit(int id) {
+        return units.get(id);
+    }
+
+    /**
+     * @see IHasUnits#addUnit(Unit, int)
+     */
+    @Override
+    public void addUnit(int position, Unit unit) {
+        unit.setOwner(this);
+        units.add(position, (CUnit) unit);
+    }
+
+    /**
+     * @see IHasUnits#addUnit(Unit)
+     */
+    @Override
+    public void addUnit(Unit unit) {
+        unit.setOwner(this);
+        units.add((CUnit) unit);
+    }
+
+    /**
+     * @see IHasUnits#removeUnit(int)
+     */
+    @Override
+    public boolean removeUnit(int id) {
+        CUnit unit = units.get(id);
+        
+        if (unit != null) {
+            unit.setOwner(null);
+            units.remove(id);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @see IHasUnits#getUnitCount()
+     */
+    @Override
+    public int getUnitCount() {
+        return units.count();
+    }
+
+    /**
+     * @see IHasUnits#countUnits(int, int)
+     */
+    @Override
+    public int countUnits(int type, int weightClass) {
+        return units.count(type, weightClass);
+    }
+
+    /**
+     * @see IHasUnits#clear()
+     */
+    @Override
+    public void clearUnits() {
+        units.clear();
     }
 
     public boolean decodeCommand(String command) {
@@ -883,17 +958,17 @@ public class CPlayer extends Player<CUnit> {
 
         // run third sort
         if ((tertiarySort != primarySort) && (tertiarySort != secondarySort) && (tertiarySort != CUnitComparator.HQSORT_NONE)) {
-            sortUnits(new CUnitComparator(tertiarySort));
+            getUnits().sort(new CUnitComparator(tertiarySort));
         }
 
         // run the second sort
         if ((primarySort != secondarySort) && (secondarySort != CUnitComparator.HQSORT_NONE)) {
-            sortUnits(new CUnitComparator(secondarySort));
+            getUnits().sort(new CUnitComparator(secondarySort));
         }
 
         // now the primary sort
         if (primarySort != CUnitComparator.HQSORT_NONE) {
-            sortUnits(new CUnitComparator(primarySort));
+            getUnits().sort(new CUnitComparator(primarySort));
         }
     }
 

--- a/MekWarsCommon/src/mekwars/common/Army.java
+++ b/MekWarsCommon/src/mekwars/common/Army.java
@@ -67,11 +67,11 @@ public class Army<T extends Unit> {
     private List<Integer> commanders = new ArrayList<Integer>(1);
     private float rawForceSize = -1;
     private Set<String> legalOperations = new TreeSet<>();
-    private Player<T> owner;
+    private Player owner;
 
     public Army() {}
 
-    public Army(Player<T> owner) {
+    public Army(Player owner) {
         this.owner = owner;
     }
 
@@ -271,7 +271,7 @@ public class Army<T extends Unit> {
         return id;
     }
 
-    public Player<T> getOwner() {
+    public Player getOwner() {
         return owner;
     }
 
@@ -595,8 +595,8 @@ public class Army<T extends Unit> {
         }
 
         Army<?> army = (Army<?>) object;
-        Player<?> owner = getOwner();
-        Player<?> otherOwner = army.getOwner();
+        Player owner = getOwner();
+        Player otherOwner = army.getOwner();
 
         return (!Objects.equals(getId(), army.getId()))
                 && Objects.equals(

--- a/MekWarsCommon/src/mekwars/common/Player.java
+++ b/MekWarsCommon/src/mekwars/common/Player.java
@@ -22,24 +22,19 @@
 package mekwars.common;
 
 import mekwars.common.campaign.PersonalPilotQueues;
+import mekwars.common.composition.IHasUnits;
 import mekwars.common.flags.PlayerFlags;
 import mekwars.common.util.UnitUtils;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
 
-public class Player<T extends Unit> {
+public abstract class Player implements IHasUnits {
     private static final Logger LOGGER = LogManager.getLogger(Player.class);
     private static final double INITIAL_RATING = 1600;
 
-    private List<T> units = new ArrayList<>();
     private String name = "";
     private String logo = "";
     private House myHouse = null;
@@ -120,15 +115,6 @@ public class Player<T extends Unit> {
         return getMyHouse().isClan();
     }
 
-    public T getUnit(int unitId) {
-        for (T currU : units) {
-            if (currU.getId() == unitId) {
-                return currU;
-            }
-        }
-        return null;
-    }
-
     public void setTotalTechs(int slot, int techs) {
         if (slot < 0 || slot >= UnitUtils.TECH_TYPES) {
             return;
@@ -159,18 +145,6 @@ public class Player<T extends Unit> {
         return availableTechs;
     }
 
-    public List<T> getUnits() {
-        return Collections.unmodifiableList(units);
-    }
-
-    public void sortUnits(Comparator<? super T> comparator) {
-        Collections.sort(units, comparator);
-    }
-
-    // @salient
-    public int getUnitCount() {
-        return units.size();
-    }
 
     public int getRewardPoints() {
         return rewardPoints;
@@ -425,34 +399,6 @@ public class Player<T extends Unit> {
     }
 
     /**
-     * A method to count the units of a given type and weight in a player's hangar
-     *
-     * @param uType
-     * @param uWeightClass
-     * @return number of units
-     */
-    public int countUnits(int uType, int uWeightClass) {
-        if ((uType < 0) || (uType > Unit.AERO)) {
-            LOGGER.error("Invalid uType {}", uType);
-            return 0;
-        }
-        if ((uWeightClass < 0) || (uWeightClass > Unit.ASSAULT)) {
-            LOGGER.error("Invalid uWeightClass {}", uWeightClass);
-            return 0;
-        }
-        // Actually count them now
-        int count = 0;
-        for (Unit u : units) {
-            if (!u.isChristmasUnit()
-                    && (u.getType() == uType)
-                    && (u.getWeightClass() == uWeightClass)) {
-                count++;
-            }
-        }
-        return count;
-    }
-
-    /**
      * A method to determine if the player is over the unit limit and the server is configured to
      * use sliding hangar cost increases
      */
@@ -505,24 +451,6 @@ public class Player<T extends Unit> {
             }
         }
         return penalty;
-    }
-
-    /**
-     * Remove a unit from the player's hangar. Called from PL after receipt of a PL|RU|ID
-     * (RemoveUnit#ID) command.
-     *
-     * <p>Note that there is NOT an analagous addUnit() method. Single additions are sent to the
-     * clients using (obtusely enough) the PL|HD (hangar data) command. See .setHangarData()'s
-     * comments, as well as those in SUnit.addUnit(), for details/explanation.
-     */
-    public boolean removeUnit(int unitID) {
-        for (Iterator<T> i = units.iterator(); i.hasNext(); ) {
-            if (i.next().getId() == unitID) {
-                i.remove();
-                return true;
-            }
-        }
-        return false;
     }
 
     /**
@@ -626,14 +554,5 @@ public class Player<T extends Unit> {
          * again if possible.
          */
         setCurrentTechPayment(Math.max(0, Math.round(amountToPay)));
-    }
-
-    protected void clearUnits() {
-        units.clear();
-    }
-
-    protected void addUnit(T unit) {
-        units.add(unit);
-        unit.setOwner(this);
     }
 }

--- a/MekWarsCommon/src/mekwars/common/campaign/pilot/PilotQueueFormatter.java
+++ b/MekWarsCommon/src/mekwars/common/campaign/pilot/PilotQueueFormatter.java
@@ -39,7 +39,7 @@ public class PilotQueueFormatter {
      * @return The string containing the contents of every weight class's current pilots for the
      *     player.
      */
-    public static <T extends Unit> String renderAllPilotLists(Player<T> player) {
+    public static String renderAllPilotLists(Player player) {
         StringBuilder pilotListBuilder = new StringBuilder();
 
         pilotListBuilder.append(renderPilotSection(player, "Mek Pilots", Unit.MEK));
@@ -48,8 +48,7 @@ public class PilotQueueFormatter {
         return pilotListBuilder.toString();
     }
 
-    public static <T extends Unit> String renderPilotSection(
-            Player<T> player, String title, int sectionType) {
+    public static String renderPilotSection(Player player, String title, int sectionType) {
         // set up a string buffer to contain the return info
         StringBuilder builder = new StringBuilder();
 

--- a/MekWarsCommon/src/mekwars/common/composition/HasUnits.java
+++ b/MekWarsCommon/src/mekwars/common/composition/HasUnits.java
@@ -1,0 +1,104 @@
+/*
+ * MekWars - Copyright (C) 2026
+ *
+ * Derived from MegaMekNET (http://www.sourceforge.net/projects/megameknet)
+ * Original author Helge Richter (McWizard)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+package mekwars.common.composition;
+
+import mekwars.common.Unit;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+public class HasUnits<T extends Unit> {
+    private List<T> units = new ArrayList<>();
+
+    /**
+     * @see IHasUnits#getUnits
+     */
+    public List<T> getAll() {
+        return units;
+    }
+
+    /**
+     * @see IHasUnits#getUnit(int)
+     */
+    public T get(int id) {
+        for (T unit : units) {
+            if (unit.getId() == id) {
+                return unit;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @see IHasUnits#addUnit(Unit, int)
+     */
+    public void add(int position, T unit) {
+        units.add(position, unit);
+    }
+
+    /**
+     * @see IHasUnits#addUnit(Unit)
+     */
+    public void add(T unit) {
+        units.add(unit);
+    }
+
+    /**
+     * @see IHasUnits#removeUnit(int)
+     */
+    public boolean remove(int id) {
+        return units.removeIf(unit -> unit.getId() == id);
+    }
+
+    /**
+     * @see IHasUnits#getUnitCount()
+     */
+    public int count() {
+        return units.size();
+    }
+
+    /**
+     * @see IHasUnits#countUnits(int, int)
+     */
+    public int count(int type, int weightClass) {
+        if ((type < 0) || (type > Unit.AERO)) {
+            return 0;
+        }
+        if ((weightClass < 0) || (weightClass > Unit.ASSAULT)) {
+            return 0;
+        }
+        // Actually count them now
+        int count = 0;
+        for (Unit unit : units) {
+            if (!unit.isChristmasUnit()
+                    && (unit.getType() == type)
+                    && (unit.getWeightClass() == weightClass)) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /**
+     * @see IHasUnits#clear()
+     */
+    public void clear() {
+        units.clear();
+    }
+}

--- a/MekWarsCommon/src/mekwars/common/composition/IHasUnits.java
+++ b/MekWarsCommon/src/mekwars/common/composition/IHasUnits.java
@@ -1,0 +1,73 @@
+/*
+ * MekWars - Copyright (C) 2026
+ *
+ * Derived from MegaMekNET (http://www.sourceforge.net/projects/megameknet)
+ * Original author Helge Richter (McWizard)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+package mekwars.common.composition;
+
+import mekwars.common.Unit;
+
+import java.util.Comparator;
+import java.util.List;
+
+public interface IHasUnits {
+    /**
+     * Returns an unmodifiable list of all units.
+     * @return An unmodifiable list of all units.
+     */
+    List<? extends Unit> getUnits();
+
+    /**
+     * Get the unit with the given id or null if it is not in the list.
+     * @return The Unit with the given id or null.
+     */
+    Unit getUnit(int id);
+
+    /**
+     * Adds a unit to the given position.
+     */
+    void addUnit(int position, Unit unit);
+
+    /**
+     * Adds a unit to the end of the list.
+     */
+    void addUnit(Unit unit);
+
+    /**
+     * Removes a single unit with the given id.
+     * @return true if the unit has been removed, otherwise false.
+     */
+    boolean removeUnit(int id);
+
+    /**
+     * Returns how many units are stored.
+     * @return How many units are stored.
+     */
+    int getUnitCount();
+
+    /**
+     * Counts the units of a given type and weight
+     *
+     * @param type
+     * @param weightClass
+     * @return number of units matching the given type and weight.
+     */
+    int countUnits(int type, int weightClass);
+
+    /**
+     * Removes all units from the list.
+     */
+    void clearUnits();
+}

--- a/MekWarsCommon/unittests/mekwars/common/PlayerTest.java
+++ b/MekWarsCommon/unittests/mekwars/common/PlayerTest.java
@@ -27,11 +27,11 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class PlayerTest {
-
     @Mock private CampaignData campaignData;
 
     @Mock private CampaignOptions campaignOptions;
@@ -40,11 +40,11 @@ class PlayerTest {
 
     @Mock private House house;
 
-    private Player<Unit> player;
+    private Player player;
 
     @BeforeEach
     void setup() {
-        player = new Player<>();
+        player = Mockito.mock(Player.class, Mockito.CALLS_REAL_METHODS);
 
         player.setMyHouse(house);
         when(campaignData.getCampaignOptions()).thenReturn(campaignOptions);
@@ -59,7 +59,7 @@ class PlayerTest {
         }
 
         @Test
-        void testDoPayTechniciansMath_ZeroTechnicians() {
+        void testZeroTechnicians() {
             player.setTechnicians(0);
             player.doPayTechniciansMath();
 
@@ -68,7 +68,7 @@ class PlayerTest {
         }
 
         @Test
-        void testDoPayTechniciansMath_NegativeAdditivePertech() {
+        void testNegativeAdditivePertech() {
             player.setTechnicians(1);
             when(houseOptions.getFloatConfig("AdditivePerTech")).thenReturn(-0.04f);
             when(houseOptions.getFloatConfig("AdditiveCostCeiling")).thenReturn(1.20f);
@@ -91,7 +91,7 @@ class PlayerTest {
             }
 
             @Test
-            void testDoPayTechniciansMath_OneTechnician() {
+            void testOneTechnician() {
                 player.setTechnicians(1);
                 player.doPayTechniciansMath();
 
@@ -100,7 +100,7 @@ class PlayerTest {
             }
 
             @Test
-            void testDoPayTechniciansMath_MultipleTechniciansBelowCeiling() {
+            void testMultipleTechniciansBelowCeiling() {
                 player.setTechnicians(5);
                 player.doPayTechniciansMath();
 
@@ -109,7 +109,7 @@ class PlayerTest {
             }
 
             @Test
-            void testDoPayTechniciansMath_TechniciansAboveCeiling() {
+            void testTechniciansAboveCeiling() {
                 player.setTechnicians(35);
                 player.doPayTechniciansMath();
 

--- a/MekWarsServer/src/mekwars/server/campaign/SPlayer.java
+++ b/MekWarsServer/src/mekwars/server/campaign/SPlayer.java
@@ -21,6 +21,8 @@ import java.math.BigDecimal;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.Iterator;
@@ -34,6 +36,7 @@ import mekwars.common.SubFaction;
 import mekwars.common.Unit;
 import mekwars.common.campaign.pilot.Pilot;
 import mekwars.common.campaign.pilot.skills.PilotSkill;
+import mekwars.common.composition.HasUnits;
 import mekwars.common.flags.PlayerFlags;
 import mekwars.common.util.TokenReader;
 import mekwars.common.util.UnitComponents;
@@ -67,7 +70,7 @@ import org.apache.logging.log4j.Logger;
  * - Moved slice flu generation to a Quartz task
  */
 
-public final class SPlayer extends Player<SUnit> implements Comparable<Object>, IBuyer, ISeller {
+public final class SPlayer extends Player implements Comparable<SPlayer>, IBuyer, ISeller {
     private static final Logger LOGGER = LogManager.getLogger(SPlayer.class);
 
     // STATIC VARIABLES
@@ -92,6 +95,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
 
     private long lastOnline = 0;
 
+    private HasUnits<SUnit> units = new HasUnits<>();
     private List<SArmy> armies = new ArrayList<>();
 
     private SPersonalPilotQueues personalPilotQueue = new SPersonalPilotQueues();
@@ -157,6 +161,79 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
      */
     public SHouse getMyHouse() {
         return (SHouse) super.getMyHouse();
+    }
+
+    /**
+     * @see IHasUnits#getUnits
+     */
+    @Override
+    public List<SUnit> getUnits() {
+        return (List<SUnit>) Collections.unmodifiableList(units.getAll());
+    }
+
+    /**
+     * @see IHasUnits#getUnit(int)
+     */
+    @Override
+    public SUnit getUnit(int id) {
+        return units.get(id);
+    }
+
+    /**
+     * @see IHasUnits#addUnit(Unit, int)
+     */
+    @Override
+    public void addUnit(int position, Unit unit) {
+        unit.setOwner(this);
+        units.add(position, (SUnit) unit);
+    }
+
+    /**
+     * @see IHasUnits#addUnit(Unit)
+     */
+    @Override
+    public void addUnit(Unit unit) {
+        unit.setOwner(this);
+        units.add((SUnit) unit);
+    }
+
+    /**
+     * @see IHasUnits#removeUnit(int)
+     */
+    @Override
+    public boolean removeUnit(int id) {
+        SUnit unit = units.get(id);
+        
+        if (unit != null) {
+            unit.setOwner(null);
+            units.remove(id);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @see IHasUnits#getUnitCount()
+     */
+    @Override
+    public int getUnitCount() {
+        return units.count();
+    }
+
+    /**
+     * @see IHasUnits#countUnits(int, int)
+     */
+    @Override
+    public int countUnits(int type, int weightClass) {
+        return units.count(type, weightClass);
+    }
+
+    /**
+     * @see IHasUnits#clear()
+     */
+    @Override
+    public void clearUnits() {
+        units.clear();
     }
 
     /**
@@ -306,22 +383,6 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
     }
 
     /**
-     * Return an SUnit with a given unique ID. If the player doesn't own the
-     * unit, return a null.
-     *
-     * @param int - id the the unit to return
-     * @return the desired unit, or null.
-     */
-    public SUnit getUnit(int id) {
-        for (SUnit currU : getUnits()) {
-            if (currU.getId() == id) {
-                return currU;
-            }
-        }
-        return null;
-    }
-
-    /**
      * ISeller-compliant .removeUnit(). Simply get the unit ID and pass to
      * normal SPlayer.removeUnit(int,bool). Use the (int,boolean) version of
      * remove unit whenever possible in order to intelligently pass select the
@@ -347,7 +408,7 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
     public void removeUnit(int unitId, boolean sendArmyUpdate) {
         SUnit Mech = null;
 
-        super.removeUnit(unitId);
+        removeUnit(unitId);
         for (SArmy currA : getArmies()) {
             if (currA.getUnitPosition(unitId) > -1) {
                 currA.removeUnit(unitId);
@@ -2273,14 +2334,14 @@ public final class SPlayer extends Player<SUnit> implements Comparable<Object>, 
     }
 
     // Comparable
-    public int compareTo(Object o) {
-        SPlayer p = (SPlayer) o;
-        if (getRating() > p.getRating()) {
+    @Override
+    public int compareTo(SPlayer player) {
+        if (getRating() > player.getRating()) {
             return 1;
-        } else if (getRating() < p.getRating()) {
+        } else if (getRating() < player.getRating()) {
             return -1;
         }
-        return p.getName().compareTo(getName());
+        return player.getName().compareTo(getName());
     }
 
     public int getScrapsThisTick() {

--- a/MekWarsServer/src/mekwars/server/campaign/util/ChristmasHandler.java
+++ b/MekWarsServer/src/mekwars/server/campaign/util/ChristmasHandler.java
@@ -409,7 +409,7 @@ public class ChristmasHandler {
 	 * @param unitFileName the unit to be created
 	 * @return SUnit the unit
 	 */
-	private <T extends Unit> SUnit getUnit(String unitFileName, Player<T> player) {
+	private SUnit getUnit(String unitFileName, Player player) {
 		SUnit u;
 		String fluff = "Merry Christmas!";
 		int gunnery = 4;


### PR DESCRIPTION
I was wrong when months ago I said having `Player` have a template was ok. In the Hibernate work since we now want to add things like `private Player owner` to many different fields for OneToOne/OneToMany, etc relationships that single template is now causing a lot of trouble.

As in the recent faction trait PR I added `Player` to `Unit` and forgot to parameterize it, fixing it is a no go. I looked into it and I would have to change `Unit` to:
```
public class Unit <T extends<Unit<T>> {
  private Pilot<T> pilot;
  private Player<T> owner;
...
}
```
The above is necessary since `Pilot` has a player, and `Unit` has a `Player` and `Planet` also has a player. 

Here I attempt to fix the issue by using composition. This is just a proof of concept so I only did `Unit`, but ultimately this pattern of `IHasUnits`, `HasUnits` would be intended to be duplicated for any other class that has a similar problem. On the positive side of this PR, since `Army` also has a list of `Unit` this can be used there to allow `Army` to use this collection of `Unit` methods for whatever its worth.

For the downsides, having a `PlayerTest` class for `Player` tests, and a `TestPlayer` class that is used to mock an abstract class is weird and confusing. `SPlayer` also has `public void addUnit(SUnit m, boolean isNew)`, and `public String addUnit(SUnit m, boolean isNew, boolean sendUpdates)` methods, which makes it confusing to know which method to use. These ultimately can't be removed yet as they are defined in the `IBuyer` interface, but it seems that `isNew` is 90% if not always true, and `sendUpdates` is only false once when used in `NewbieHouse` so hopefully it wouldn't be to difficult to change in a followup PR.

The one concern I have is every `addUnit` method needs to have `unit.setOwner(this);` copy pasted into 4 different methods. I could definitely see some bugs coming out of this with someone forgetting to add a method call to all of the different methods. 

The most important problem I think this PR will have is how to cleanly turn the `HasUnit` class into a `OneToMany` relationship like a `List` would when this gets migrated to Hibernate.