### PR TITLE
Add BasePilotStats

### DIFF
--- a/MekWarsClient/src/mekwars/client/MWClient.java
+++ b/MekWarsClient/src/mekwars/client/MWClient.java
@@ -2009,22 +2009,7 @@ public final class MWClient extends GameHost implements IClient {
     }// end PurgeAutoSaves
 
     public void createNewHouse(StringTokenizer st) {
-        House house = new House();
-
-        house.setId(TokenReader.readInt(st));
-        house.setName(TokenReader.readString(st));
-        house.setLogo(TokenReader.readString(st));
-        house.setBaseGunner(TokenReader.readInt(st));
-        house.setBasePilot(TokenReader.readInt(st));
-        house.setHouseColor(TokenReader.readString(st));
-        house.setHousePlayerColors(TokenReader.readString(st));
-        house.setAbbreviation(TokenReader.readString(st));
-        house.setConquerable(TokenReader.readBoolean(st));
-        house.setTechLevel(TokenReader.readInt(st));
-        house.setHouseDefectionFrom(TokenReader.readBoolean(st));
-        house.setHouseDefectionTo(TokenReader.readBoolean(st));
-        house.setUsedMekBayMultiplier(TokenReader.readFloat(st));
-        getData().addHouse(house);
+        getData().addHouse(new House(st));
     }
 
     /**

--- a/MekWarsClient/src/mekwars/client/campaign/CBMUnit.java
+++ b/MekWarsClient/src/mekwars/client/campaign/CBMUnit.java
@@ -85,8 +85,8 @@ public class CBMUnit {
 		 * vehicles) or just gunnery (misc. infantry types).
 		 */
 		if (!hidden) {
-			int factionGunnery = campaign.getPlayer().getMyHouse().getBaseGunner();
-			int factionPiloting = campaign.getPlayer().getMyHouse().getBasePilot();
+			int factionGunnery = campaign.getPlayer().getMyHouse().getBasePilotStats().getGunnery();
+			int factionPiloting = campaign.getPlayer().getMyHouse().getBasePilotStats().getPiloting();
             House owner = campaign.getPlayer().getMyHouse();
 
 			if ((embeddedUnit.getType() == Unit.MEK) || (embeddedUnit.getType() == Unit.VEHICLE)) {

--- a/MekWarsClient/src/mekwars/client/gui/CHQPanel.java
+++ b/MekWarsClient/src/mekwars/client/gui/CHQPanel.java
@@ -3070,7 +3070,7 @@ public class CHQPanel extends JPanel {
             CArmy army = getArmyAt(row);
             StringBuilder result = new StringBuilder(cm.getModelName());
             // TODO: When registering as a new player the player's house is null for a second.
-            String skillSet = cm.getPilot().getSkillString(false, mwclient.getData().getHouseByName(mwclient.getPlayer().getHouse()).getBasePilotSkill(cm.getType()));
+            String skillSet = cm.getPilot().getSkillString(false, mwclient.getData().getHouseByName(mwclient.getPlayer().getHouse()).getBasePilotStats().getSkills(cm.getType()));
             StringTokenizer skills = new StringTokenizer(skillSet, ",");
             while (skills.hasMoreElements()) {
                 skills.nextElement();

--- a/MekWarsClient/src/mekwars/client/gui/formatter/UnitFormatter.java
+++ b/MekWarsClient/src/mekwars/client/gui/formatter/UnitFormatter.java
@@ -143,8 +143,8 @@ public class UnitFormatter {
                             .getSkillString(
                                     false,
                                     mwclient.getData()
-                                            .getHouseByName(mwclient.getPlayer().getHouse())
-                                            .getBasePilotSkill(unit.getType()));
+                                            .getHouseByName(mwclient.getPlayer().getHouse()).getBasePilotStats()
+                                            .getSkills(unit.getType()));
             tinfo += "<br>";
         }
 

--- a/MekWarsCommon/src/mekwars/common/House.java
+++ b/MekWarsCommon/src/mekwars/common/House.java
@@ -25,19 +25,20 @@ import mekwars.common.persistence.EntityStore;
 import mekwars.common.util.BinReader;
 import mekwars.common.util.BinWriter;
 import mekwars.common.util.HTMLConverter;
+import mekwars.common.util.TokenReader;
 import mekwars.common.universe.FactionTag;
+import mekwars.common.campaign.BasePilotStats;
 import megamek.common.TechConstants;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.Set;
-import java.util.Vector;
+import java.util.StringTokenizer;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ConcurrentHashMap;
@@ -58,12 +59,6 @@ public class House implements Entity {
     private String factionFluFile = "Common";
 
     private int id;
-    private Vector<Integer> baseGunner = new Vector<Integer>(Unit.MAXBUILD, 1);
-    private Vector<Integer> basePilot = new Vector<Integer>(Unit.MAXBUILD, 1);
-    private Vector<String> basePilotSkills = new Vector<String>(Unit.MAXBUILD, 1);
-
-    // private int factionPlayerColors[] = new int[3]; // [red,green,blue]
-
     private int factionUnitPriceMod[][] = new int[Unit.MAXBUILD][4]; // [Type][Weight]
     private int factionUnitFluMod[][] = new int[Unit.MAXBUILD][4]; // [Type][Weight]
     private int factionUnitComponentMod[][] = new int[Unit.MAXBUILD][4]; // [Type][Weight]
@@ -71,6 +66,7 @@ public class House implements Entity {
     private String factionColor = "#000000";
     private String abbreviation = "";
     private String factionPlayerColors = "#000000";
+    private BasePilotStats basePilotStats;
 
     private boolean conquerable = true;
 
@@ -86,116 +82,14 @@ public class House implements Entity {
     private Set<FactionTag> tags = EnumSet.noneOf(FactionTag.class);
 
     /**
-     * @return Returns the baseGunner.
-     */
-    public int getBaseGunner() {
-        return baseGunner.elementAt(0);
-    }
-
-    /**
-     * @return baseGunner vector
-     */
-    public Vector<Integer> getBaseGunnerVect() {
-        return baseGunner;
-    }
-
-    /**
-     * @return Returns the baseGunner.
-     */
-    public int getBaseGunner(int type) {
-        return baseGunner.elementAt(type);
-    }
-
-    /**
-     * @return basePilotSkills vector
-     */
-    public Vector<String> getBasePilotSkillVect() {
-        return basePilotSkills;
-    }
-
-    /**
-     * @return Returns the basePilotSkill String.
-     */
-    public String getBasePilotSkill(int type) {
-        return basePilotSkills.elementAt(type);
-    }
-
-    /**
-     * @param baseGunner
-     *            The baseGunner to set.
-     */
-    public void setBaseGunner(int baseGunner) {
-        synchronized(this.baseGunner) {
-            this.baseGunner.set(0, baseGunner);
-        }
-    }
-
-    /**
-     * @param basePilotSkill
-     *            The base piloting skill for unit <code>type</code> to set.
-     */
-    public void setBasePilotSkill(String basePilotSkill, int type) {
-        synchronized(this.basePilotSkills) {
-            this.basePilotSkills.set(type, basePilotSkill);
-        }
-    }
-
-    /**
-     * @param baseGunner
-     *            The baseGunner to set.
-     */
-    public void setBaseGunner(int baseGunner, int type) {
-        synchronized(this.baseGunner) {
-            this.baseGunner.set(type, baseGunner);
-        }
-    }
-
-    /**
-     * @return Returns the basePilot.
-     */
-    public int getBasePilot() {
-        return basePilot.elementAt(0);
-    }
-
-    /**
-     * @return Returns the basePilot.
-     */
-    public int getBasePilot(int type) {
-        return basePilot.elementAt(type);
-    }
-
-    /**
-     * @return basePilot vector
-     */
-    public Vector<Integer> getBasePilotVect() {
-        return basePilot;
-    }
-
-    /**
-     * @param basePilot
-     *            The basePilot to set.
-     */
-    public void setBasePilot(int basePilot) {
-        synchronized(this.basePilot) {
-            this.basePilot.set(0, basePilot);
-        }
-    }
-
-    /**
-     * @param basePilot
-     *            The basePilot to set.
-     */
-    public void setBasePilot(int basePilot, int type) {
-        synchronized(this.basePilot) {
-            this.basePilot.set(type, basePilot);
-        }
-    }
-
-    /**
      * @return Returns the myAbbreviation.
      */
     public String getAbbreviation() {
         return abbreviation;
+    }
+
+    public BasePilotStats getBasePilotStats() {
+        return basePilotStats;
     }
 
     /**
@@ -294,11 +188,23 @@ public class House implements Entity {
 
     public House() {
         setId(EntityStore.UNSET_ID);
-        for (int pos = 0; pos < Unit.MAXBUILD; pos++) {
-            baseGunner.add(4);
-            basePilot.add(5);
-            basePilotSkills.add(" ");
-        }
+        basePilotStats = new BasePilotStats();
+    }
+
+    public House(StringTokenizer st) {
+        setId(TokenReader.readInt(st));
+        setName(TokenReader.readString(st));
+        setLogo(TokenReader.readString(st));
+        getBasePilotStats().setGunnery(TokenReader.readInt(st), Unit.MEK);
+        getBasePilotStats().setPiloting(TokenReader.readInt(st), Unit.MEK);
+        setHouseColor(TokenReader.readString(st));
+        setHousePlayerColors(TokenReader.readString(st));
+        setAbbreviation(TokenReader.readString(st));
+        setConquerable(TokenReader.readBoolean(st));
+        setTechLevel(TokenReader.readInt(st));
+        setHouseDefectionFrom(TokenReader.readBoolean(st));
+        setHouseDefectionTo(TokenReader.readBoolean(st));
+        setUsedMekBayMultiplier(TokenReader.readFloat(st));
     }
 
     /**
@@ -308,8 +214,7 @@ public class House implements Entity {
         out.println(id, "id");
         out.println(name, "name");
         out.println(logo, "logo");
-        out.println(getBaseGunner(), "baseGunner");
-        out.println(getBasePilot(), "basePilot");
+        basePilotStats.binOut(out);
         out.println(factionColor, "factionColor");
 
         out.println(factionPlayerColors, "factionPlayerColor");
@@ -326,10 +231,6 @@ public class House implements Entity {
         for (int type = 0; type < Unit.MAXBUILD; type++)
             for (int weight = 0; weight < 4; weight++)
                 out.println(this.getHouseUnitFluMod(type, weight), "fluMod" + type + weight);
-
-        for (int pos = 0; pos < Unit.MAXBUILD; pos++) {
-            out.println(basePilotSkills.elementAt(pos), "factionBasePilotSkill");
-        }
 
         out.println(this.getTechLevel(), "techLevel");
         out.println(this.getHouseDefectionFrom(), "defectFrom");
@@ -362,17 +263,10 @@ public class House implements Entity {
      * Read itself from a stream.
      */
     public House(BinReader in) throws IOException {
-        for (int pos = 0; pos < Unit.MAXBUILD; pos++) {
-            baseGunner.add(4);
-            basePilot.add(5);
-            basePilotSkills.add(" ");
-        }
-
         id = in.readInt("id");
         name = HTMLConverter.br2cr(in.readLine("name"));
         logo = HTMLConverter.br2cr(in.readLine("logo"));
-        setBaseGunner(in.readInt("baseGunner"));
-        setBasePilot(in.readInt("basePilot"));
+        basePilotStats = new BasePilotStats(in);
         factionColor = in.readLine("factionColor");
 
         factionPlayerColors = in.readLine("factionPlayerColor");
@@ -396,10 +290,6 @@ public class House implements Entity {
             for (int weight = 0; weight < 4; weight++) {
                 this.setHouseUnitFluMod(type, weight, in.readInt("fluMod" + type + weight));
             }
-        }
-
-        for (int pos = 0; pos < Unit.MAXBUILD; pos++) {
-            basePilotSkills.set(pos, in.readLine("factionBasePilotSkill"));
         }
 
         this.setTechLevel(in.readInt("techLevel"));
@@ -634,9 +524,9 @@ public class House implements Entity {
         else
             result.append(logo);
         result.append("|");
-        result.append(getBaseGunner());
+        result.append(getBasePilotStats().getGunnery(Unit.MEK));
         result.append("|");
-        result.append(getBasePilot());
+        result.append(getBasePilotStats().getPiloting(Unit.MEK));
         result.append("|");
         result.append(factionColor);
         result.append("|");

--- a/MekWarsCommon/src/mekwars/common/campaign/BasePilotStats.java
+++ b/MekWarsCommon/src/mekwars/common/campaign/BasePilotStats.java
@@ -1,0 +1,86 @@
+/*
+ * MekWars - Copyright (C) 2026
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+package mekwars.common.campaign;
+
+import mekwars.common.Unit;
+import mekwars.common.util.BinReader;
+import mekwars.common.util.BinWriter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class BasePilotStats {
+    private List<Integer> gunnery = new ArrayList<Integer>(Unit.MAXBUILD);
+    private List<Integer> piloting = new ArrayList<Integer>(Unit.MAXBUILD);
+    private List<String> pilotSkills = new ArrayList<String>(Unit.MAXBUILD);
+
+    public BasePilotStats() {
+        for (int pos = 0; pos < Unit.MAXBUILD; pos++) {
+            gunnery.add(4);
+            piloting.add(5);
+            pilotSkills.add(" ");
+        }
+    }
+
+    public BasePilotStats(BinReader in) throws IOException {
+        this();
+        gunnery.set(0, in.readInt("baseGunner"));
+        piloting.set(0, in.readInt("basePilot"));
+        for (int pos = 0; pos < Unit.MAXBUILD; pos++) {
+            pilotSkills.set(pos, in.readLine("factionBasePilotSkill"));
+        }
+    }
+
+    public void binOut(BinWriter out) throws IOException {
+        out.println(getGunnery(Unit.MEK), "baseGunner");
+        out.println(getPiloting(Unit.MEK), "basePilot");
+        for (int pos = 0; pos < Unit.MAXBUILD; pos++) {
+            out.println(pilotSkills.get(pos), "factionBasePilotSkill");
+        }
+    }
+
+    public int getGunnery() {
+        return getGunnery(Unit.MEK);
+    }
+
+    public int getGunnery(Integer type) {
+        return gunnery.get(type);
+    }
+
+    public void setGunnery(Integer gunnerySkill, int type) {
+        gunnery.set(type, gunnerySkill);
+    }
+
+    public int getPiloting() {
+        return piloting.get(Unit.MEK);
+    }
+
+    public int getPiloting(Integer type) {
+        return piloting.get(type);
+    }
+
+    public void setPiloting(Integer pilotingSkill, int type) {
+        piloting.set(type, pilotingSkill);
+    }
+
+    public String getSkills(Integer type) {
+        return pilotSkills.get(type);
+    }
+
+    public void setSkills(String skills, Integer type) {
+        pilotSkills.set(type, skills);
+    }
+}

--- a/MekWarsServer/src/mekwars/server/campaign/PilotQueues.java
+++ b/MekWarsServer/src/mekwars/server/campaign/PilotQueues.java
@@ -24,9 +24,9 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.StringTokenizer;
-import java.util.Vector;
+import java.util.List;
 
 import mekwars.common.CampaignData;
 import mekwars.common.Unit;
@@ -43,27 +43,23 @@ import org.apache.logging.log4j.Logger;
 
 public class PilotQueues {
     private static final Logger LOGGER = LogManager.getLogger(PilotQueues.class);
+    public static final int MIN_PILOTS = 10;
 
-    private Vector<LinkedList<SPilot>> queues = new Vector<LinkedList<SPilot>>(Unit.MAXBUILD,1);
-	private Vector<Integer> baseGunnery = new Vector<Integer>(Unit.MAXBUILD,1);
-	private Vector<Integer> basePiloting = new Vector<Integer>(Unit.MAXBUILD,1);
-	private Vector<String>  basePilotSkills = new Vector<String>(Unit.MAXBUILD,1);
+    private List<List<SPilot>> queues = new ArrayList<>(Unit.MAXBUILD);
     private SHouse owner;
 	private BufferedReader dis;
 	
-	public PilotQueues(SHouse owner, Vector<Integer>baseGunnery, Vector<Integer>basePiloting, Vector<String>basePilotSkill) {
-        this.owner = owner;
-		for (int i = Unit.MEK; i < Unit.MAXBUILD; i++) {
-			LinkedList<SPilot> v = new LinkedList<SPilot>();
-			queues.add(i,v);
-		}
-		this.baseGunnery = baseGunnery;
-		this.basePiloting = basePiloting;
-		this.basePilotSkills = basePilotSkill;
-	}
-	
 	public PilotQueues() {
-		//Only needed for XStream
+        this.queues = new ArrayList<>(Unit.MAXBUILD);
+        for (int i = Unit.MEK; i < Unit.MAXBUILD; i++) {
+            List<SPilot> pilotList = new ArrayList<SPilot>();
+            queues.add(i, pilotList);
+        }
+	}
+
+	public PilotQueues(SHouse owner) {
+        this();
+        this.owner = owner;
 	}
 
     public SHouse getOwner() {
@@ -106,9 +102,9 @@ public class PilotQueues {
 		if (!skipSkillChange) {
 			this.addPilot(type, p);
 		}
-		else {//skip the skill adjustmebnt
-			queues.get(type).addLast(p);
-		}//end else(bypass the adjustmenbt)
+		else {//skip the skill adjustment
+			queues.get(type).add(p);
+		}//end else(bypass the adjustment)
 	}
 	
 	/**
@@ -140,7 +136,7 @@ public class PilotQueues {
 	        }
 	    }
 
-	    if (CampaignMain.cm.getBooleanConfig("ReduceSkillsInQue")) {
+	    if (CampaignData.cd.getCampaignOptions().getBooleanConfig("ReduceSkillsInQue")) {
 			int rnd = CampaignMain.cm.getRandomNumber(100);
 			if (rnd >= CampaignMain.cm.getIntegerConfig("ClearXPInQue")) {
 				p.setExperience(0);
@@ -197,9 +193,7 @@ public class PilotQueues {
 				}//end else(piloting less or equal)
 			}//end else if(both pilot and gunner have skill improvements)
 		}//end if(downgrade elites)
-		
-		queues.get(type).addLast(p);
-
+		queues.get(type).add(p);
 	}//end void addPilot()
 	
 	/**
@@ -211,12 +205,12 @@ public class PilotQueues {
 	 * from the dat files without reprocessing them.
 	 */
 	public void loadPilot(int type, SPilot p) {
-	    queues.get(type).addLast(p);
+	    queues.get(type).add(p);
 	}//end void loadPilot()
 	
 	public SPilot getPilot(int type) {
-		LinkedList<SPilot> list = queues.get(type);
-		while (list.size() < 10)  {
+		List<SPilot> list = queues.get(type);
+		while (list.size() < MIN_PILOTS)  {
 			addPilot(type, rollNewPilot(type), true);
         }
 		
@@ -224,10 +218,12 @@ public class PilotQueues {
 		
 		StringTokenizer ST = new StringTokenizer(getBasePilotSkill(type),"$");
 		
-		while ( ST.hasMoreTokens() ) {
+		while (ST.hasMoreTokens()) {
 		    PilotSkill pSkill = PilotSkillStore.getPilotSkill(ST.nextToken());
-		    if ( !pilot.getSkills().has(pSkill) )
-			pilot.getSkills().add(pSkill);
+
+		    if (!pilot.getSkills().has(pSkill)) {
+                pilot.getSkills().add(pSkill);
+            }
 		}
 		
 		return pilot;
@@ -287,14 +283,14 @@ public class PilotQueues {
 	 * @return int this queue's base piloting #
 	 */
 	public int getBasePiloting(int type) {
-		return this.basePiloting.elementAt(type);
+        return owner.getBasePilotStats().getPiloting(type);
 	}
 	
 	/**
 	 * @return int this queue's base gunnery #
 	 */
 	public int getBaseGunnery(int type) {
-		return this.baseGunnery.elementAt(type);
+        return owner.getBasePilotStats().getGunnery(type);
 	}
 	
 	/**
@@ -302,33 +298,7 @@ public class PilotQueues {
 	 * @return base piloting skills for specific unit type.
 	 */
 	public String getBasePilotSkill(int type) {
-	    return this.basePilotSkills.elementAt(type);
-	}
-	
-	/*
-	 * Sets BasePiloting for this queue
-	 */
-	
-	public void setBasePiloting(int piloting,int type){
-	    synchronized(basePiloting) {
-	    	this.basePiloting.set(type,piloting);
-	    }
-	}
-	
-	/*
-	 * Sets Base Gunnery for this queue
-	 */
-	
-	public void setBaseGunnery(int gunnery,int type){
-	    synchronized(baseGunnery) {
-	    	this.baseGunnery.set(type,gunnery);
-	    }
-	}
-	
-	public void setBasePilotSkill(String skills, int type) {
-	    synchronized(basePilotSkills) {
-	    	this.basePilotSkills.set(type,skills);
-	    }
+        return owner.getBasePilotStats().getSkills(type);
 	}
 	
 	/**
@@ -339,7 +309,6 @@ public class PilotQueues {
 	 * newbie faction units and for units generated with CreateMechCommand.
 	 */
 	public String getRandomPilotName() {
-		
 		String result = "Noelle";//something we hope never returns
         if (CampaignMain.cm.getBooleanConfig("UseCommonPilotNameFileOnly"))
         	return SPilot.getRandomPilotName(CampaignMain.cm.getR());
@@ -354,7 +323,6 @@ public class PilotQueues {
         		String line = dis.readLine();
         		if (pilotid <= 0)
         			return line;
-        		//else
         		pilotid--;
         	}
 
@@ -362,29 +330,26 @@ public class PilotQueues {
         	fis.close();
 
         } catch (Exception e) {
-        	LOGGER.error("A problem occured while retreiving a name from the " + owner.getName() + " Pilotnames File! Tried using Pilotnames.txt instead.");
+        	LOGGER.error("A problem occured while retrieving a name from the " + owner.getName() + " Pilotnames File! Tried using Pilotnames.txt instead.");
         	result = SPilot.getRandomPilotName(CampaignMain.cm.getR());
-        }finally{
-        	
         }
         
 	    return result;
 	  }//end getRandomPilotName
 	
-	public LinkedList<SPilot> getPilotQueue(int type) {
-		LinkedList<SPilot> list = queues.get(type);
-		return list;
+	public List<SPilot> getPilotQueue(int type) {
+		return queues.get(type);
 	}
 
 	/**
 	 * Obliterate all queued pilots.
 	 */
 	public void flushQueue() {
-            queues.removeAllElements();
-            for (int i = Unit.MEK; i < Unit.MAXBUILD; i++) {
-            	LinkedList<SPilot> v = new LinkedList<SPilot>();
-            	queues.add(v);
-            }
-	}
+        queues.clear();
 
+        for (int i = Unit.MEK; i < Unit.MAXBUILD; i++) {
+            List<SPilot> v = new ArrayList<SPilot>();
+            queues.add(v);
+        }
+	}
 }

--- a/MekWarsServer/src/mekwars/server/campaign/SHouse.java
+++ b/MekWarsServer/src/mekwars/server/campaign/SHouse.java
@@ -107,8 +107,7 @@ public class SHouse extends TimeUpdateHouse
     private String motd = "";
     private String announcement = "";
 
-    private PilotQueues pilotQueues =
-            new PilotQueues(this, getBaseGunnerVect(), getBasePilotVect(), getBasePilotSkillVect());
+    private PilotQueues pilotQueues = new PilotQueues(this);
 
     private List<String> leaders = new ArrayList<>();
     private int techResearchPoints = 0;
@@ -125,8 +124,8 @@ public class SHouse extends TimeUpdateHouse
         result.append(getName());
         result.append(getMoney());
         result.append(getHouseColor());
-        result.append(this.getBaseGunner());
-        result.append(getBasePilot());
+        result.append(getBasePilotStats().getGunnery());
+        result.append(getBasePilotStats().getPiloting());
         result.append(getAbbreviation());
 
         result.append(hangar.count());
@@ -193,12 +192,12 @@ public class SHouse extends TimeUpdateHouse
         result.append(getHouseDefectionTo());
 
         for (int pos = 0; pos < Unit.MAXBUILD; pos++) {
-            result.append(getBaseGunner(pos));
-            result.append(getBasePilot(pos));
+            result.append(getBasePilotStats().getGunnery(pos));
+            result.append(getBasePilotStats().getPiloting(pos));
         }
 
         for (int pos = 0; pos < Unit.MAXBUILD; pos++) {
-            String skill = getBasePilotSkill(pos);
+            String skill = getBasePilotStats().getSkills(pos);
             if (skill.length() < 1) {
                 result.append(" ");
             } else {
@@ -261,8 +260,8 @@ public class SHouse extends TimeUpdateHouse
 
             setMoney(TokenReader.readInt(ST));
             setHouseColor(TokenReader.readString(ST));
-            setBaseGunner(TokenReader.readInt(ST));
-            setBasePilot(TokenReader.readInt(ST));
+            getBasePilotStats().setGunnery(TokenReader.readInt(ST), Unit.MEK);
+            getBasePilotStats().setPiloting(TokenReader.readInt(ST), Unit.MEK);
 
             setAbbreviation(TokenReader.readString(ST));
 
@@ -369,30 +368,20 @@ public class SHouse extends TimeUpdateHouse
 
             try {
                 for (int pos = 0; pos < Unit.MAXBUILD; pos++) {
-                    setBaseGunner(TokenReader.readInt(ST), pos);
-                    setBasePilot(TokenReader.readInt(ST), pos);
+                    getBasePilotStats().setGunnery(TokenReader.readInt(ST), pos);
+                    getBasePilotStats().setPiloting(TokenReader.readInt(ST), pos);
                 }
             } catch (Exception ex) {
-                setPilotQueues(
-                        new PilotQueues(
-                                this,
-                                getBaseGunnerVect(),
-                                getBasePilotVect(),
-                                getBasePilotSkillVect()));
+                setPilotQueues(new PilotQueues(this));
             }
 
             try {
                 for (int pos = 0; pos < Unit.MAXBUILD; pos++) {
                     String skill = TokenReader.readString(ST);
-                    setBasePilotSkill(skill, pos);
+                    getBasePilotStats().setSkills(skill, pos);
                 }
             } catch (Exception ex) {
-                setPilotQueues(
-                        new PilotQueues(
-                                this,
-                                getBaseGunnerVect(),
-                                getBasePilotVect(),
-                                getBasePilotSkillVect()));
+                setPilotQueues(new PilotQueues(this));
             }
 
             setTechLevel(TokenReader.readInt(ST));
@@ -444,12 +433,7 @@ public class SHouse extends TimeUpdateHouse
                 getComponentConverter().put(converter.getCritName(), converter);
             }
 
-            setPilotQueues(
-                    new PilotQueues(
-                            this,
-                            getBaseGunnerVect(),
-                            getBasePilotVect(),
-                            getBasePilotSkillVect()));
+            setPilotQueues(new PilotQueues(this));
             // faction name
             // for the queue
 
@@ -2171,8 +2155,8 @@ public class SHouse extends TimeUpdateHouse
             result.append(u.getPilot().getGunnery());
             result.append(u.getPilot().getPiloting());
         } else {
-            result.append(getBaseGunner(u.getType()));
-            result.append(getBasePilot(u.getType()));
+            result.append(getBasePilotStats().getGunnery(u.getType()));
+            result.append(getBasePilotStats().getPiloting(u.getType()));
         }
         // if using AR, send damage information
         if (CampaignMain.cm.isUsingAdvanceRepair()) {

--- a/MekWarsServer/src/mekwars/server/campaign/commands/DefectCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/DefectCommand.java
@@ -639,7 +639,6 @@ public class  DefectCommand  implements Command {
     }// end process()
 
     public SHouse createSingleFaction(String houseName, String shortName) {
-
         SHouse house = new SHouse();
         int maxHouseName = CampaignMain.cm.getIntegerConfig("MaxFactionName");
         int maxShortName = CampaignMain.cm.getIntegerConfig("MaxFactionShortName");
@@ -657,8 +656,6 @@ public class  DefectCommand  implements Command {
         house.createNoneHouse();
         house.setName(houseName);
         house.setAbbreviation(shortName);
-        house.setBaseGunner(4);
-        house.setBasePilot(5);
         house.setConquerable(true);
         house.setTechLevel(TechConstants.T_INTRO_BOXSET);
         CampaignMain.cm.addHouse(house);

--- a/MekWarsServer/src/mekwars/server/campaign/commands/FreeBuildCreateUnitCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/FreeBuildCreateUnitCommand.java
@@ -192,7 +192,9 @@ public class FreeBuildCreateUnitCommand implements Command {
 			weight = Integer.parseInt(command.nextToken());
 
 		//Note that if you look at the create method of SUnit, it appears you dont really need to pass the weight...
-		SUnit tempUnit = SUnit.create(player.getMyHouse(), filename, FlavorText, house.getBaseGunner(), house.getBasePilot(), weight, skillTokens);
+        int gunnery = house.getBasePilotStats().getGunnery();
+        int piloting = house.getBasePilotStats().getPiloting();
+		SUnit tempUnit = SUnit.create(player.getMyHouse(), filename, FlavorText, gunnery, piloting, weight, skillTokens);
         //This will create a pilot based on faction settings defined by server operator
 		SPilot tempPilot = house.getNewPilot(tempUnit.getType());
         tempUnit.setPilot(tempPilot);

--- a/MekWarsServer/src/mekwars/server/campaign/commands/admin/AdminHousePilotsCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/admin/AdminHousePilotsCommand.java
@@ -16,7 +16,7 @@
 
 package mekwars.server.campaign.commands.admin;
 
-import java.util.LinkedList;
+import java.util.List;
 import java.util.StringTokenizer;
 
 import mekwars.common.Unit;
@@ -70,9 +70,10 @@ public class AdminHousePilotsCommand implements Command {
             toReturn.append("Faction Base Pilot: " + currQ.getBaseGunnery(type) + "/" + currQ.getBasePiloting(type)+"<br>");
             toReturn.append("Faction Base Pilot Skills: " + currQ.getBasePilotSkill(type)+"<br>");
 			toReturn.append("<b>Queue for " + Unit.getTypeClassDesc(type) + ":</b><OL>");
-			LinkedList<SPilot> l = currQ.getPilotQueue(type);
-			for (SPilot currP : l)
+			List<SPilot> l = currQ.getPilotQueue(type);
+			for (SPilot currP : l) {
 				toReturn.append("<LI>"+currP.getName()+"("+currP.getGunnery()+"/"+currP.getPiloting()+") ["+currP.getSkillString(true)+"]</LI>");
+            }
 			toReturn.append("</OL>");
 		}
 		
@@ -81,8 +82,5 @@ public class AdminHousePilotsCommand implements Command {
 		CampaignMain.cm.toUser(toReturn.toString(),Username,true);
 		//server.MWLogger.modLog(Username + " checked House " + h.getName() + " Pilots");
 		CampaignMain.cm.doSendModMail("NOTE",Username + " checked House "+ h.getName() + " Pilots");
-		
-		
-		
 	}
 }

--- a/MekWarsServer/src/mekwars/server/campaign/commands/admin/SetHouseBasePilotingSkillsCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/admin/SetHouseBasePilotingSkillsCommand.java
@@ -34,7 +34,6 @@ public class SetHouseBasePilotingSkillsCommand implements Command {
 	public String getSyntax() { return syntax;}
 	
 	public void process(StringTokenizer command,String Username) {
-		
 		//access level check
 		int userLevel = MWServ.getInstance().getUserLevel(Username);
 		if(userLevel < getExecutionLevel()) {
@@ -63,12 +62,10 @@ public class SetHouseBasePilotingSkillsCommand implements Command {
                 return;
             }
 
-            house.getPilotQueues().setBasePilotSkill(skills, pilotType);
-            
+            house.getBasePilotStats().setSkills(skills, pilotType);
             house.updated();
             //log, and inform mods.
             CampaignMain.cm.toUser("You added a piloting skill for unit "+Unit.getTypeClassDesc(pilotType)+" for house "+house.getName()+" to "+skills,Username);
             CampaignMain.cm.doSendModMail("NOTE",Username + " has added a piloting skill for unit "+Unit.getTypeClassDesc(pilotType)+" for house "+house.getName()+" to "+skills+ ".");
-		
 	}//end process
 }

--- a/MekWarsServer/src/mekwars/server/campaign/commands/mod/SetHouseBasePilotSkillsCommand.java
+++ b/MekWarsServer/src/mekwars/server/campaign/commands/mod/SetHouseBasePilotSkillsCommand.java
@@ -65,8 +65,8 @@ public class SetHouseBasePilotSkillsCommand implements Command {
             return;
         }
         
-        house.getPilotQueues().setBaseGunnery(gunnery, pilotType);
-        house.getPilotQueues().setBasePiloting(piloting, pilotType);
+        house.getBasePilotStats().setGunnery(gunnery, pilotType);
+        house.getBasePilotStats().setPiloting(piloting, pilotType);
         
 		//log, and inform mods.
 		CampaignMain.cm.toUser("You set have set the gunnery and piloting for unit "+Unit.getTypeClassDesc(pilotType)+" for house "+house.getName()+" to "+gunnery+"/"+piloting,Username);

--- a/MekWarsServer/src/mekwars/server/campaign/converters/SHouseConverter.java
+++ b/MekWarsServer/src/mekwars/server/campaign/converters/SHouseConverter.java
@@ -65,11 +65,11 @@ public class SHouseConverter implements Converter {
         writer.endNode();
 
         writer.startNode("baseGunner");
-        writer.setValue(Integer.toString(house.getBaseGunner()));
+        writer.setValue(Integer.toString(house.getBasePilotStats().getGunnery()));
         writer.endNode();
 
         writer.startNode("basePilot");
-        writer.setValue(Integer.toString(house.getBasePilot()));
+        writer.setValue(Integer.toString(house.getBasePilotStats().getPiloting()));
         writer.endNode();
 
         writer.startNode("conquerable");

--- a/MekWarsServer/src/mekwars/server/campaign/operations/ShortOperation.java
+++ b/MekWarsServer/src/mekwars/server/campaign/operations/ShortOperation.java
@@ -2984,7 +2984,9 @@ public class ShortOperation implements Comparable<Object> {
         for (SUnit unit : units) {
             if (unit.hasVacantPilot()) {
                 SHouse attackingHouse = initiator.getHouseFightingFor();
-                SPilot pilot = new SPilot(unit.getOwner().getMyHouse(), SPilot.getRandomPilotName(CampaignMain.cm.getR()), attackingHouse.getBaseGunner(Unit.MEK), attackingHouse.getBasePilot(Unit.MEK));
+                int gunnery = attackingHouse.getBasePilotStats().getGunnery();
+                int piloting = attackingHouse.getBasePilotStats().getPiloting();
+                SPilot pilot = new SPilot(unit.getOwner().getMyHouse(), SPilot.getRandomPilotName(CampaignMain.cm.getR()), gunnery, piloting);
                 unit.setPilot(pilot);
             }
             results.append(defendingHouse.removeUnit(unit, false));

--- a/MekWarsServer/src/mekwars/server/campaign/pilot/SPilot.java
+++ b/MekWarsServer/src/mekwars/server/campaign/pilot/SPilot.java
@@ -329,8 +329,8 @@ public class SPilot extends Pilot {
         else if (shouldLevelDown) {
 
             // return pilot to faction base
-            setGunnery(owner.getMyHouse().getBaseGunner(unit.getType()));
-            setPiloting(owner.getMyHouse().getBasePilot(unit.getType()));
+            setGunnery(owner.getMyHouse().getBasePilotStats().getGunnery(unit.getType()));
+            setPiloting(owner.getMyHouse().getBasePilotStats().getPiloting(unit.getType()));
 
             // Store the old name for use in return, and change to successor
             // name

--- a/MekWarsServer/unittests/mekwars/server/campaign/PilotQueuesTest.java
+++ b/MekWarsServer/unittests/mekwars/server/campaign/PilotQueuesTest.java
@@ -1,0 +1,139 @@
+/*
+ * MekWars - Copyright (C) 2026
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+package mekwars.server.campaign;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
+
+import mekwars.common.CampaignData;
+import mekwars.common.Unit;
+import mekwars.common.campaign.BasePilotStats;
+import mekwars.common.campaign.CampaignOptions;
+import mekwars.server.campaign.pilot.SPilot;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+@ExtendWith(MockitoExtension.class)
+class PilotQueuesTest {
+    @Mock private SHouse house;
+
+    @Mock private CampaignMain campaignMain;
+
+    @Mock private CampaignData campaignData;
+
+    @Mock private CampaignOptions campaignOptions;
+
+    private PilotQueues pilotQueues;
+    private BasePilotStats basePilotStats;
+
+    @BeforeEach
+    public void setup() {
+        CampaignData.cd = campaignData;
+        CampaignMain.cm = campaignMain;
+
+        pilotQueues = new PilotQueues(house);
+        basePilotStats = new BasePilotStats();
+    }
+
+    @Nested
+    class AddPilotTest {
+        @Test
+        public void testNullifyVacantPilot() {
+            SPilot vacantPilot = new SPilot(house, "Vacant", 4, 5);
+            int initialSize = pilotQueues.getQueueSize(Unit.MEK);
+
+            pilotQueues.addPilot(Unit.MEK, vacantPilot, false);
+
+            assertEquals(initialSize, pilotQueues.getQueueSize(Unit.MEK));
+        }
+
+        @Test
+        public void testSkipSkillAdjustmentWhenFlagTrue() {
+            SPilot pilot = new SPilot(house, "Pilot", 3, 4);
+
+            pilotQueues.addPilot(Unit.MEK, pilot, true);
+
+            assertEquals(3, pilot.getGunnery());
+            assertEquals(4, pilot.getPiloting());
+        }
+
+        @Test
+        public void testNotReduceSkillsWhenDisabled() {
+            when(CampaignData.cd.getCampaignOptions()).thenReturn(campaignOptions);
+            when(campaignOptions.getBooleanConfig("ReduceSkillsInQue")).thenReturn(false);
+
+            SPilot pilot = new SPilot(house, "pilot", 3, 4);
+
+            pilotQueues.addPilot(Unit.MEK, pilot, false);
+
+            assertEquals(3, pilot.getGunnery());
+            assertEquals(4, pilot.getPiloting());
+        }
+
+        @Test
+        public void testAddToCorrectTypeQueue() {
+            SPilot mechPilot = new SPilot(house, "MechPilot", 4, 5);
+            SPilot vehiclePilot = new SPilot(house, "VehiclePilot", 4, 5);
+
+            pilotQueues.addPilot(Unit.MEK, mechPilot, true);
+            pilotQueues.addPilot(Unit.VEHICLE, vehiclePilot, true);
+
+            assertEquals(1, pilotQueues.getQueueSize(Unit.MEK));
+            assertEquals(1, pilotQueues.getQueueSize(Unit.VEHICLE));
+        }
+    }
+
+    @Nested
+    class GetPilotTest {
+        @BeforeEach
+        public void setup() {
+            when(house.getBasePilotStats()).thenReturn(basePilotStats);
+            when(CampaignData.cd.getCampaignOptions()).thenReturn(campaignOptions);
+            when(campaignOptions.getIntegerConfig("BornSkillChance")).thenReturn(5);
+        }
+
+        @Test
+        public void testReturnExistingPilotFromQueue() {
+            List<SPilot> queue = pilotQueues.getPilotQueue(Unit.MEK);
+            SPilot pilot = new SPilot(house, "TestPilot", 4, 5);
+            pilotQueues.addPilot(Unit.MEK, pilot);
+
+            when(campaignMain.getRandomNumber(anyInt())).thenReturn(0);
+
+            SPilot result = pilotQueues.getPilot(Unit.MEK);
+
+            assertSame(pilot, result);
+            assertEquals(PilotQueues.MIN_PILOTS - 1, queue.size());
+        }
+
+        @Test
+        public void testRefillQueueToTenBeforeReturning() {
+            when(campaignMain.getRandomNumber(anyInt())).thenReturn(0);
+
+            SPilot result = pilotQueues.getPilot(Unit.MEK);
+
+            assertNotNull(result);
+            assertEquals(PilotQueues.MIN_PILOTS - 1, pilotQueues.getQueueSize(Unit.MEK));
+        }
+    }
+}


### PR DESCRIPTION
Move `baseGunner`, `basePilot`, and `basePilotSkill` into their own class. These fields are annoying because they are initialized in `House` but are mostly used in `PilotQueues`, but they can't be put into `PilotQueues` because that is in MekWarsServer and MekWarsClient uses `baseGunner` and `basePilot` in a few spots.